### PR TITLE
[Fix] 피드 업로드 단계 뒤로가기 알람 뷰 출현 케이스 예외처리 및 자잘한 디자인 수정사항 반영

### DIFF
--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/View/WIEmptyView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/View/WIEmptyView.swift
@@ -9,11 +9,6 @@ import UIKit
 
 import SnapKit
 
-public final class ViewSingleton: NSObject {
-    static let emptyView = WIEmptyView()
-    private override init() { }
-}
-
 public final class WIEmptyView: UIView {
         
     private let emptyImg: UIImageView = {

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/View/WIEmptyView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/View/WIEmptyView.swift
@@ -73,26 +73,21 @@ public final class WIEmptyView: UIView {
         
         emptyImg.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.height.width.equalTo(342)
+            $0.height.width.equalTo(150)
         }
         
         textStack.snp.makeConstraints {
             $0.top.equalTo(emptyImg.snp.bottom)
-            $0.width.equalTo(emptyImg.snp.width)
             $0.bottom.equalToSuperview()
         }
         
         mainText.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.width.equalTo(171)
-            $0.height.equalTo(30)
             $0.centerX.equalToSuperview()
         }
         
         subText.snp.makeConstraints {
             $0.top.equalTo(mainText.snp.bottom)
-            $0.width.equalTo(217)
-            $0.height.equalTo(20)
             $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview()
         }

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -194,9 +194,7 @@ extension MyFeedViewController {
         }
         
         emptyView.snp.makeConstraints {
-            $0.top.equalTo(naviBar.snp.bottom).offset(96)
-            $0.horizontalEdges.equalToSuperview().inset(24)
-            $0.centerX.equalToSuperview()
+            $0.centerX.centerY.equalToSuperview()
         }
         
         collectionView.snp.makeConstraints {

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -84,7 +84,7 @@ final class MyFeedViewController: UIViewController {
                 self?.postFeedLike(feedId: selectedFeedId, feedLike: isLiked)
             }
             cell.moreButtonTappedClosure = { [weak self] feedId, _ in
-                self?.showAlert(feedId, indexPath.item)
+                self?.showBottomAlert(feedId: feedId, item: indexPath.item)
             }
         }
         
@@ -104,6 +104,20 @@ final class MyFeedViewController: UIViewController {
         snapshot.appendSections([0])
         snapshot.appendItems(self.myfeed)
         return snapshot
+    }
+    
+    private func showBottomAlert(feedId: Int, item: Int) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+            print("쫄?")
+        }
+        alertController.addAction(cancelAction)
+        let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in
+            self.showAlert(feedId, item)
+            self.refresh()
+        }
+        alertController.addAction(deleteAction)
+        present(alertController, animated: true, completion: nil)
     }
     
     private func showAlert(_ idx: Int, _ path: Int) {

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -191,6 +191,12 @@ extension MypageViewController: UICollectionViewDataSource {
                 saveGoalVC.modalPresentationStyle = .pageSheet
                 self?.present(saveGoalVC, animated: true, completion: nil)
             }
+            mypageGoalInfoCell.blockAlertTappedClosure = { [weak self] in
+                let blockAlert = MIPopupViewController(content: .init(title: "절약 목표 기간이 지나지 않아\n목표를 수정할 수 없어요"))
+                blockAlert.addButton(title: "닫기", type: .gray, tapButtonHandler: nil)
+                self?.present(blockAlert, animated: true)
+            }
+            
             return mypageGoalInfoCell
             
         case 2 :

--- a/Winey/Winey/Source/Scenes/MyPage/Views/Cells/MypageGoalInfoCell.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/Views/Cells/MypageGoalInfoCell.swift
@@ -29,6 +29,9 @@ final class MypageGoalInfoCell: UICollectionViewCell {
     // MARK: - Properties
 
     var saveGoalButtonTappedClosure : (() -> Void)?
+    var blockAlertTappedClosure: (() -> Void)?
+    
+    private var dday: String = ""
     
     // MARK: - UIComponents
     
@@ -212,7 +215,7 @@ final class MypageGoalInfoCell: UICollectionViewCell {
     
     @objc
     private func modifyButtonTapped() {
-        self.saveGoalButtonTappedClosure?()
+        ["아직 없어요", "D-0"].contains(dday) ? self.saveGoalButtonTappedClosure?() : self.blockAlertTappedClosure?()
     }
     
     // MARK: - View Life Cycle
@@ -268,7 +271,8 @@ final class MypageGoalInfoCell: UICollectionViewCell {
             )
         }
         
-        let dday = model.dday == nil ? "아직 없어요" : "D-\(model.dday ?? 0)"
+        dday = model.dday == nil ? "아직 없어요" : "D-\(model.dday ?? 0)"
+        
         savingPeriodLabel.setText(
             dday,
             attributes: .init(
@@ -277,6 +281,7 @@ final class MypageGoalInfoCell: UICollectionViewCell {
                 textColor: .winey_gray900
             )
         )
+        
         savingPeriodLabel.textAlignment = .center
         wineyCountLabel.textAlignment = .center
         accumulatedWineyLabel.textAlignment = .center

--- a/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
@@ -19,7 +19,7 @@ class ContentsWriteView: UIView {
     private let placeholder = "Ex) 버스 타고 가는 길을 운동 삼아 20분 일찍 일어나 걸어갔어요!"
     var textSendClousre: ((_ data: String) -> Void)?
     
-    var textCountPublisher = PassthroughSubject<Int, Never>()
+    var textCountPublisher = PassthroughSubject<(Int, Bool), Never>()
     
     // MARK: - UI Components
     
@@ -105,7 +105,7 @@ extension ContentsWriteView: UITextViewDelegate {
             textView.text = nil
         }
         setColor(textView.text.count)
-        textCountPublisher.send(textView.text.count)
+        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     /// textViewDidEndEditing: 텍스트 뷰의 편집이 종료되었을때의 동작을 정의한 함수
@@ -118,13 +118,13 @@ extension ContentsWriteView: UITextViewDelegate {
             setColor(textView.text.count)
         }
         textView.makeBorder(width: 1, color: .winey_gray200)
-        textCountPublisher.send(textView.text.count)
+        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     /// textViewDidChange: 텍스트 뷰가 편집되었을때의 동작을 정의한 함수
     func textViewDidChange(_ textView: UITextView) {
         textSendClousre?(textView.text ?? "")
-        textCountPublisher.send(textView.text.count)
+        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     func resetContents() {

--- a/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
@@ -5,6 +5,7 @@
 //  Created by 김응관 on 2023/07/13.
 //
 
+import Combine
 import UIKit
 
 import DesignSystem
@@ -17,6 +18,8 @@ class ContentsWriteView: UIView {
     /// textSendClosure:  선택된 이미지객체를 ViewController로 전달하기 위해 사용되는 클로저
     private let placeholder = "Ex) 버스 타고 가는 길을 운동 삼아 20분 일찍 일어나 걸어갔어요!"
     var textSendClousre: ((_ data: String) -> Void)?
+    
+    var textCountPublisher = PassthroughSubject<Int, Never>()
     
     // MARK: - UI Components
     
@@ -102,6 +105,7 @@ extension ContentsWriteView: UITextViewDelegate {
             textView.text = nil
         }
         setColor(textView.text.count)
+        textCountPublisher.send(textView.text.count)
     }
     
     /// textViewDidEndEditing: 텍스트 뷰의 편집이 종료되었을때의 동작을 정의한 함수
@@ -114,11 +118,13 @@ extension ContentsWriteView: UITextViewDelegate {
             setColor(textView.text.count)
         }
         textView.makeBorder(width: 1, color: .winey_gray200)
+        textCountPublisher.send(textView.text.count)
     }
     
     /// textViewDidChange: 텍스트 뷰가 편집되었을때의 동작을 정의한 함수
     func textViewDidChange(_ textView: UITextView) {
         textSendClousre?(textView.text ?? "")
+        textCountPublisher.send(textView.text.count)
     }
     
     func resetContents() {

--- a/Winey/Winey/Source/Scenes/Upload/View/PriceUploadView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/PriceUploadView.swift
@@ -5,6 +5,7 @@
 //  Created by 김응관 on 2023/07/14.
 //
 
+import Combine
 import UIKit
 
 import DesignSystem
@@ -16,12 +17,15 @@ class PriceUploadView: UIView {
     /// textContentView: Winey에서 사용될 커스텀 TextField인 WITextFieldView객체를 선언
     var textContentView = WITextFieldView(type: .upload_price)
     
+    private var bag = Set<AnyCancellable>()
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setLayout()
         textContentView.changeTextLength(9)
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -37,6 +41,20 @@ class PriceUploadView: UIView {
         } else {
             textContentView.resign()
         }
+    }
+    
+    private func bind() {
+        textContentView.pricePublisher
+            .sink { _ in
+                self.textContentView.makeActiveView()
+            }
+            .store(in: &bag)
+        
+        textContentView.textFieldDidEndEditingPublisher
+            .sink {
+                self.textContentView.makeInactiveView()
+            }
+            .store(in: &bag)
     }
     
     private func setLayout() {

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -101,22 +101,6 @@ class UploadViewController: UIViewController {
         return btn
     }()
     
-    private lazy var alert: MIPopupViewController = {
-        let vc = MIPopupViewController(content: .init(
-            title: "지금 나가시면 작성하신 게 지워져요",
-            subtitle: "절약 실천 게시물을 올리시면 레벨업에 가까워져요\n그래도 나가시겠습니까?")
-        )
-        
-        vc.addButton(title: "취소", type: .gray) {
-            vc.dismiss(animated: true)
-        }
-        
-        vc.addButton(title: "나가기", type: .yellow) {
-            self.gotoFront()
-        }
-        return vc
-    }()
-    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -330,11 +314,20 @@ class UploadViewController: UIViewController {
     
     @objc
     private func tapLeftButton() {
-        if navigationBar.leftBarItem == .back {
-            self.present(alert, animated: true)
-        } else {
-            self.dismissUploadViewController()
+        let vc = MIPopupViewController(content: .init(
+            title: "지금 나가시면 작성하신 게 지워져요",
+            subtitle: "절약 실천 게시물을 올리시면 레벨업에 가까워져요\n그래도 나가시겠습니까?")
+        )
+        
+        vc.addButton(title: "취소", type: .gray) {
+            vc.dismiss(animated: true)
         }
+        
+        vc.addButton(title: "나가기", type: .yellow) {
+            self.navigationBar.leftBarItem == .back ? self.gotoFront() : self.dismissUploadViewController()
+        }
+        
+        self.present(vc, animated: true)
     }
     
     @objc

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -65,6 +65,8 @@ class UploadViewController: UIViewController {
         }
     }
     
+    private var textExist: Bool = false
+    
     private let postService = FeedService()
     
     private let imagePicker = UIImagePickerController()
@@ -137,6 +139,12 @@ class UploadViewController: UIViewController {
         thirdPageSubject
             .sink { [weak self] _ in
                 self?.thirdPage.textContentView.resetPrice()
+            }
+            .store(in: &bag)
+        
+        secondPage.textCountPublisher
+            .sink { [weak self] count in
+                self?.textExist = count > 0 ? true : false
             }
             .store(in: &bag)
     }
@@ -314,20 +322,28 @@ class UploadViewController: UIViewController {
     
     @objc
     private func tapLeftButton() {
-        let vc = MIPopupViewController(content: .init(
-            title: "지금 나가시면 작성하신 게 지워져요",
-            subtitle: "절약 실천 게시물을 올리시면 레벨업에 가까워져요\n그래도 나가시겠습니까?")
-        )
-        
-        vc.addButton(title: "취소", type: .gray) {
-            vc.dismiss(animated: true)
+        if isOk || (stageIdx == 1 && textExist){
+            let vc = MIPopupViewController(content: .init(
+                title: "지금 나가시면 작성하신 게 지워져요",
+                subtitle: "절약 실천 게시물을 올리시면 레벨업에 가까워져요\n그래도 나가시겠습니까?")
+            )
+            
+            vc.addButton(title: "취소", type: .gray) {
+                vc.dismiss(animated: true)
+            }
+            
+            vc.addButton(title: "나가기", type: .yellow) {
+                self.setNaviBtn(self.navigationBar.leftBarItem)
+            }
+            
+            self.present(vc, animated: true)
+        } else {
+            setNaviBtn(self.navigationBar.leftBarItem)
         }
-        
-        vc.addButton(title: "나가기", type: .yellow) {
-            self.navigationBar.leftBarItem == .back ? self.gotoFront() : self.dismissUploadViewController()
-        }
-        
-        self.present(vc, animated: true)
+    }
+    
+    private func setNaviBtn(_ type: WINavigationBar.BarItem?) {
+        type == .back ? self.gotoFront() : self.dismissUploadViewController()
     }
     
     @objc

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -143,8 +143,8 @@ class UploadViewController: UIViewController {
             .store(in: &bag)
         
         secondPage.textCountPublisher
-            .sink { [weak self] count in
-                self?.textExist = count > 0 ? true : false
+            .sink { [weak self] (count, result) in
+                self?.textExist = count > 0 && !result ? true : false
             }
             .store(in: &bag)
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/ #134, #135 

👷 **작업한 내용**
[#134]
- 절약 목표 기간이 아직 남아 있을 경우에 수정 불가 알림이 버튼 터치 시에 뜨도록 수정
- 마이피드 우측 상단 햄버거 버튼 누르면 UIAlertViewController가 먼저뜨고, 거기서 삭제하기 누르면 삭제 관련 Alert가 뜨도록 수정
- EmptyView 이미지 사이즈/레이아웃 조정된 사항 반영하여 수정

[#135]
- 첫 번째 단계에서 X버튼 누르면 UploadVC dismiss 되게끔 설정
- 첫 번째 단계에서 이미지가 갤러리에서 선택이 안되었다면 알람 안뜨게 하기
- 두 번째 단계에서 절약 내용이 1자 이상 입력되면, 뒤로가기 누를 때 알람 뜰 수 있게 수정
- 두 번째 단계에서 절약 내용이 작성되지 않았다면, 뒤로가기 누를 때 알람 안뜨게 설정
- 세 번째 단계에서 금액이 입력되지 않았다면, 뒤로가기 누를 때 알람 안뜨게 설정

## 🚨참고 사항
잔버그나 예외처리할 사항 더 있으면 알려주세요

## 📟 관련 이슈
- Resolved: #134 #135 
