### PR TITLE
[Fix] #151 - iOS 자체 QA

### DIFF
--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/Button/DuplicateCheckButton.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/Button/DuplicateCheckButton.swift
@@ -30,7 +30,7 @@ public final class DuplicateCheckButton: UIButton {
                                                                            weight: .medium,
                                                                            textColor: .winey_gray700))
         setAttributedTitle(btnText, for: .normal)
-        backgroundColor = .winey_gray50
+        backgroundColor = .winey_yellow
         makeCornerRound(radius: 5)
     }
 }

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextField+Type.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextField+Type.swift
@@ -21,6 +21,7 @@ public struct WITextFieldType {
     public let labelWidth: CGFloat
     public let labelColor: UIColor
     public let activeTextColor: UIColor
+    public let activeBorderColor: UIColor
     
     public init(
         textLeftPadding: CGFloat,
@@ -35,7 +36,8 @@ public struct WITextFieldType {
         placeholder: String,
         labelWidth: CGFloat,
         labelColor: UIColor,
-        activeTextColor: UIColor
+        activeTextColor: UIColor,
+        activeBorderColor: UIColor
     ) {
         self.textLeftPadding = textLeftPadding
         self.textRightPadding = textRightPadding
@@ -50,6 +52,7 @@ public struct WITextFieldType {
         self.labelWidth = labelWidth
         self.labelColor = labelColor
         self.activeTextColor = activeTextColor
+        self.activeBorderColor = activeBorderColor
     }
 }
 
@@ -68,7 +71,8 @@ public extension WITextFieldType {
         placeholder: TextField.price.placeholder,
         labelWidth: TextField.price.labelWidth,
         labelColor: TextField.price.labelColor,
-        activeTextColor: TextField.price.activeTextColor
+        activeTextColor: TextField.price.activeTextColor,
+        activeBorderColor: TextField.price.activeBorderColor
     )
     
     static let day: WITextFieldType = WITextFieldType(
@@ -84,8 +88,8 @@ public extension WITextFieldType {
         placeholder: TextField.day.placeholder,
         labelWidth: TextField.day.labelWidth,
         labelColor: TextField.day.labelColor,
-        activeTextColor: TextField.day.activeTextColor
-
+        activeTextColor: TextField.day.activeTextColor,
+        activeBorderColor: TextField.day.activeBorderColor
     )
     
     static let nickName: WITextFieldType = WITextFieldType(
@@ -102,7 +106,8 @@ public extension WITextFieldType {
         placeholder: TextField.nickName.placeholder,
         labelWidth: TextField.nickName.labelWidth,
         labelColor: TextField.nickName.labelColor,
-        activeTextColor: TextField.nickName.activeTextColor
+        activeTextColor: TextField.nickName.activeTextColor,
+        activeBorderColor: TextField.nickName.activeBorderColor
     )
 }
 
@@ -205,6 +210,15 @@ extension WITextFieldType {
         }
         
         var activeTextColor: UIColor {
+            switch self {
+            case .price, .day:
+                return .winey_purple400
+            case .nickName:
+                return .winey_gray900
+            }
+        }
+        
+        var activeBorderColor: UIColor {
             switch self {
             case .price, .day:
                 return .winey_purple400

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
@@ -182,6 +182,10 @@ public final class WITextFieldView: UIView {
     public func getName() -> String {
         return textField.text ?? ""
     }
+    
+    public func setName(_ name: String) {
+        textField.text = name
+    }
 }
 
 extension WITextFieldView: UITextFieldDelegate {

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
@@ -161,7 +161,7 @@ public final class WITextFieldView: UIView {
     }
     
     public func makeActiveView() {
-        textField.makeBorder(width: Size.borderWidth.rawValue, color: Color.activeColor.color)
+        textField.makeBorder(width: Size.borderWidth.rawValue, color: type.activeBorderColor)
         textField.textColor = type.activeTextColor
     }
     

--- a/Winey/Winey/Source/Scenes/Login/View/LoginView.swift
+++ b/Winey/Winey/Source/Scenes/Login/View/LoginView.swift
@@ -26,12 +26,6 @@ final class LoginView: UIView {
         return text
     }()
     
-    private let character: UIImageView = {
-        let img = UIImageView()
-        img.image = .Login.character?.resizeWithWidth(width: 280)
-        return img
-    }()
-    
     // MARK: - Init func
     
     override init(frame: CGRect) {
@@ -46,23 +40,18 @@ final class LoginView: UIView {
     // MARK: - Methods
     
     private func setLayout() {
-        addSubviews(logo, title, character)
+        addSubviews(logo, title)
         
         logo.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(27)
-            $0.leading.equalToSuperview().inset(57)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(67)
+            $0.width.equalTo(196)
         }
         
         title.snp.makeConstraints {
             $0.top.equalTo(logo.snp.bottom).offset(2)
-            $0.leading.equalToSuperview().inset(80)
-            $0.trailing.equalToSuperview().inset(50)
-        }
-        
-        character.snp.makeConstraints {
-            $0.top.equalTo(title.snp.bottom).offset(88)
-            $0.horizontalEdges.equalToSuperview()
+            $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
     }

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -29,6 +29,12 @@ class LoginViewController: UIViewController {
     
     // MARK: - UI Components
     
+    private let character: UIImageView = {
+        let img = UIImageView()
+        img.image = .Login.character?.resizeWithWidth(width: 280)
+        return img
+    }()
+    
     private let appleButton: LoginButton = {
         let button = LoginButton(type: .apple)
         return button
@@ -37,6 +43,12 @@ class LoginViewController: UIViewController {
     private let kakaoButton: LoginButton = {
         let button = LoginButton(type: .kakao)
         return button
+    }()
+    
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        return stack
     }()
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
@@ -71,16 +83,22 @@ class LoginViewController: UIViewController {
     }
     
     private func setLayout() {
-        view.addSubviews(loginView, kakaoButton, appleButton, activityIndicator)
+        view.addSubviews(loginView, character, kakaoButton, appleButton, activityIndicator)
         
         loginView.snp.makeConstraints {
-            $0.top.equalTo(safeArea).offset(72)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(72)
+            $0.height.equalTo(93)
+            $0.centerX.equalToSuperview()
+        }
+        
+        character.snp.makeConstraints {
+            $0.top.equalTo(loginView.snp.bottom).offset(88)
             $0.leading.equalToSuperview().inset(40)
             $0.trailing.equalToSuperview().inset(70)
         }
         
         kakaoButton.snp.makeConstraints {
-            $0.top.equalTo(loginView.snp.bottom).offset(48)
+            $0.top.equalTo(character.snp.bottom).offset(48)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(54)
         }
@@ -89,6 +107,7 @@ class LoginViewController: UIViewController {
             $0.top.equalTo(kakaoButton.snp.bottom).offset(10)
             $0.horizontalEdges.equalTo(kakaoButton.snp.horizontalEdges)
             $0.height.equalTo(54)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(64)
         }
     }
     

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -45,12 +45,6 @@ class LoginViewController: UIViewController {
         return button
     }()
     
-    private let stackView: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .vertical
-        return stack
-    }()
-    
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
         activityIndicator.frame = CGRect(x: 0, y: 0, width: 100, height: 100)

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -175,6 +175,7 @@ extension MypageViewController: UICollectionViewDataSource {
                 
                 let nicknameViewController = NicknameViewController(viewType: .myPage)
                 nicknameViewController.hidesBottomBarWhenPushed = true
+                nicknameViewController.configureNickname(nickname)
                 self.navigationController?.pushViewController(nicknameViewController, animated: true)
             }
             return mypageProfileCell

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -173,10 +173,9 @@ extension MypageViewController: UICollectionViewDataSource {
                 let logEvent = LogEventImpl(category: .click_edit_nickname)
                 AmplitudeManager.logEvent(event: logEvent)
                 
-                let nicknameViewController = UINavigationController(rootViewController: NicknameViewController(viewType: .myPage))
-                nicknameViewController.setNavigationBarHidden(true, animated: false)
-                nicknameViewController.modalPresentationStyle = .fullScreen
-                self.present(nicknameViewController, animated: true, completion: nil)
+                let nicknameViewController = NicknameViewController(viewType: .myPage)
+                nicknameViewController.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(nicknameViewController, animated: true)
             }
             return mypageProfileCell
             

--- a/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
+++ b/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
@@ -231,7 +231,7 @@ class NicknameViewController: UIViewController {
     
     @objc
     private func tapLeftButton() {
-        self.dismiss(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
     
     @objc

--- a/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
+++ b/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
@@ -24,6 +24,11 @@ class NicknameViewController: UIViewController {
     private let nicknameService = NicknameService()
     
     private var recentNickname: String = ""
+    private var originalNickname: String = "" {
+        didSet {
+            nickNameTextField.setName(originalNickname)
+        }
+    }
     
     private var duplicateResult: Bool = false
     
@@ -227,6 +232,10 @@ class NicknameViewController: UIViewController {
         } else {
             nextButton.isEnabled = false
         }
+    }
+    
+    func configureNickname(_ name: String) {
+        originalNickname = name
     }
     
     @objc

--- a/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
@@ -116,6 +116,11 @@ extension ContentsWriteView: UITextViewDelegate {
         } else {
             textView.textColor = .winey_gray900
             setColor(textView.text.count)
+            
+            if textView.text.count > 36 {
+                textView.text.removeLast()
+                textNum.text = "(36/36)"
+            }
         }
         textView.makeBorder(width: 1, color: .winey_gray200)
         textCountPublisher.send((textView.text.count, textView.text == placeholder))
@@ -123,6 +128,8 @@ extension ContentsWriteView: UITextViewDelegate {
     
     /// textViewDidChange: 텍스트 뷰가 편집되었을때의 동작을 정의한 함수
     func textViewDidChange(_ textView: UITextView) {
+        if textView.text.count > 36 { textView.resignFirstResponder() }
+        
         textSendClousre?(textView.text ?? "")
         textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
@@ -144,10 +151,29 @@ extension ContentsWriteView: UITextViewDelegate {
             textView.resignFirstResponder()
             return false
         } else {
-            let changedText = currentText.replacingCharacters(in: stringRange, with: text)
-            setColor(changedText.count)
-            textNum.text = "(\(changedText.count)/36)"
-            return changedText.count <= 35
+            let newLength = textView.text.count - range.length + text.count
+            let koreanMaxCount = 37
+            
+            if newLength > koreanMaxCount {
+                let overflow = newLength - koreanMaxCount
+                if text.count < overflow {
+                    return true
+                }
+                let index = text.index(text.endIndex, offsetBy: -overflow)
+                let newText = text[..<index]
+                guard let startPosition = textView.position(from: textView.beginningOfDocument, offset: range.location) else { return false }
+                guard let endPosition = textView.position(from: textView.beginningOfDocument, offset: NSMaxRange(range)) else { return false }
+                guard let textRange = textView.textRange(from: startPosition, to: endPosition) else { return false }
+                    
+                textView.replace(textRange, withText: String(newText))
+                textNum.text = "(36/36)"
+                
+                return false
+            } else {
+                setColor(newLength)
+                textNum.text = "(\(newLength)/36)"
+                return true
+            }
         }
     }
     

--- a/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
@@ -143,9 +143,7 @@ extension ContentsWriteView: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         
         let currentText = textView.text ?? ""
-        
-        guard let stringRange = Range(range, in: currentText) else { return false }
-        
+                
         if text == "\n" {
             textNum.text = "(\(currentText.count)/36)"
             textView.resignFirstResponder()

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -287,6 +287,11 @@ class UploadViewController: UIViewController {
         view.addGestureRecognizer(tapGesture)
     }
     
+    private func textValidation(text: String) -> Bool {
+        let pureText = text.trimmingCharacters(in: .whitespaces)
+        return pureText.count > 0
+    }
+    
     /// setButtonActivate
     /// 업로드 단계에 따라 버튼이 활성화 될 지 말지를 결정해주는 함수
     private func setButtonActivate(_ step: Int) {
@@ -298,7 +303,7 @@ class UploadViewController: UIViewController {
                 isOk = false
             }
         case 1:
-            if feedTitle.count >= 5 {
+            if feedTitle.count >= 5 && textValidation(text: feedTitle) {
                 isOk = true
             } else {
                 isOk = false


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#151

👷 **작업한 내용**
- 닉네임 수정 뷰 진입 방식 변경 -> pushToVC로
- 닉네임 수정 뷰 진입하면 원래 닉네임이 텍스트필드에 올려져있게하기
- 중복확인버튼 색상변경
- 닉네임 텍스트 뷰 활성화 상태일 때 텍스트필드 테두리 색상 변경
- 로그인 뷰 레이아웃 수정
- 절약 내용 입력 텍스트뷰에 공백만 5개이상 입력되었을시 버튼 활성화되는 경우 예외처리
- 절약 내용 입력 텍스트뷰 한글 36자 온전히 다 입력안되는 에러 수정
- 절약 내용 입력 텍스트뷰 내용 복사 붙여넣기 하면 36자까지만 짤려서 보이게끔 수정

## 🚨참고 사항
오류나면 알려주세요

## 📟 관련 이슈
- Resolved: #151 
