### PR TITLE
[Fix] #156 - 응관 2번째 자체 QA 

### DIFF
--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
@@ -151,10 +151,6 @@ public final class WITextFieldView: UIView {
         textField.resignFirstResponder()
     }
     
-    public func resetPrice() {
-        textField.text = "0"
-    }
-    
     public func makeErrorView() {
         textField.makeBorder(width: Size.borderWidth.rawValue, color: Color.errorBorderColor.color)
         textField.textColor = Color.errorTextColor.color

--- a/Winey/Winey.xcodeproj/project.pbxproj
+++ b/Winey/Winey.xcodeproj/project.pbxproj
@@ -1415,7 +1415,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 66PR7H87SL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Winey/Resource/info.plist;
@@ -1455,7 +1455,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 66PR7H87SL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Winey/Resource/info.plist;

--- a/Winey/Winey/Source/Global/Extension/Foundation+/NotificationName+.swift
+++ b/Winey/Winey/Source/Global/Extension/Foundation+/NotificationName+.swift
@@ -18,4 +18,6 @@ extension Notification.Name {
     static let feedUploadResult = Notification.Name(rawValue: "feedUploadResult")
     /// 피드 삭제후 노티
     static let whenDeleteFeedCompleted = Notification.Name(rawValue: "whenDeleteFeedCompleted")
+    /// 마이피드 삭제후 노티
+    static let whenMyfeedDeleteCompleted = Notification.Name(rawValue: "whenMyfeedDeleteCompleted")
 }

--- a/Winey/Winey/Source/Global/Extension/Foundation+/NotificationName+.swift
+++ b/Winey/Winey/Source/Global/Extension/Foundation+/NotificationName+.swift
@@ -18,6 +18,4 @@ extension Notification.Name {
     static let feedUploadResult = Notification.Name(rawValue: "feedUploadResult")
     /// 피드 삭제후 노티
     static let whenDeleteFeedCompleted = Notification.Name(rawValue: "whenDeleteFeedCompleted")
-    /// 마이피드 삭제후 노티
-    static let whenMyfeedDeleteCompleted = Notification.Name(rawValue: "whenMyfeedDeleteCompleted")
 }

--- a/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
@@ -251,18 +251,9 @@ final class FeedViewController: UIViewController {
         
         deletePopup.addButton(title: "삭제하기", type: .yellow) {
             self.deleteMyFeed(feedId: feedId)
-            self.deleteCell(item)
         }
         
         self.present(deletePopup, animated: true)
-    }
-    
-    func deleteCell(_ path: Int) {
-        var snapshot = dataSource.snapshot()
-        let targetItem = snapshot.itemIdentifiers[path]
-        snapshot.deleteItems([targetItem])
-        dataSource.apply(snapshot)
-        feedList.remove(at: path)
     }
     
     @objc

--- a/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
@@ -28,6 +28,7 @@ final class FeedViewController: UIViewController {
     private var currentPage: Int = 1
     private var isEnd: Bool = false
     
+    private var feedDeletePublisher = PassthroughSubject<Void, Never>()
     private var bag = Set<AnyCancellable>()
     
     private var currentBannerType: BannerState = .initial
@@ -250,6 +251,7 @@ final class FeedViewController: UIViewController {
         deletePopup.addButton(title: "삭제하기", type: .yellow) {
             self.deleteMyFeed(feedId: feedId)
             self.refresh()
+            self.feedDeletePublisher.send((Void()))
         }
         
         self.present(deletePopup, animated: true)
@@ -414,7 +416,9 @@ extension FeedViewController {
     
     private func deleteMyFeed(feedId: Int) {
         feedService.deleteMyFeed(feedId) { [weak self] response in
-            response ? self?.showToast(.feedDeleteSuccess) : self?.showToast(.feedDeleteFail)
+            guard let self = self else { return }
+            response ? self.showToast(.feedDeleteSuccess) : self.showToast(.feedDeleteFail)
+            self.dataSource.apply(self.snapshot(), animatingDifferences: false)
         }
     }
     

--- a/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
@@ -74,6 +74,7 @@ final class FeedViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         checkNewNotification()
+        refresh()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -210,11 +211,6 @@ final class FeedViewController: UIViewController {
                 self?.showToast(type)
             })
             .store(in: &bag)
-        NotificationCenter.default.publisher(for: .whenMyfeedDeleteCompleted)
-            .sink(receiveValue: { [weak self] _ in
-                self?.refresh()
-            })
-            .store(in: &bag)
     }
     
     private func refresh() {
@@ -254,13 +250,8 @@ final class FeedViewController: UIViewController {
         deletePopup.addButton(title: "취소", type: .gray, tapButtonHandler: nil)
         
         deletePopup.addButton(title: "삭제하기", type: .yellow) {
-            DispatchQueue.global(qos: .userInteractive).async {
-                self.deleteMyFeed(feedId: feedId)
-            }
-            
+            self.deleteMyFeed(feedId: feedId)
             self.deleteCell(item)
-            self.refresh()
-            self.feedDeletePublisher.send((Void()))
         }
         
         self.present(deletePopup, animated: true)
@@ -435,7 +426,8 @@ extension FeedViewController {
         feedService.deleteMyFeed(feedId) { [weak self] response in
             guard let self = self else { return }
             response ? self.showToast(.feedDeleteSuccess) : self.showToast(.feedDeleteFail)
-            self.dataSource.apply(self.snapshot(), animatingDifferences: false)
+            self.refresh()
+            // self.dataSource.apply(self.snapshot(), animatingDifferences: false)
         }
     }
     

--- a/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
@@ -210,6 +210,11 @@ final class FeedViewController: UIViewController {
                 self?.showToast(type)
             })
             .store(in: &bag)
+        NotificationCenter.default.publisher(for: .whenMyfeedDeleteCompleted)
+            .sink(receiveValue: { [weak self] _ in
+                self?.refresh()
+            })
+            .store(in: &bag)
     }
     
     private func refresh() {

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -210,6 +210,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
                     self.kakaoButton.isHidden = true
                     self.appleButton.isHidden = true
                     self.loginView.isHidden = true
+                    self.character.isHidden = true
                     // 2. 이 VC로 왔다는 것은 로그인이 필요한 상황 -> identityToken을 통한 Token들 재발급이 필요함
                     DispatchQueue.global(qos: .background).async {
                         

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -148,6 +148,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
                 self.kakaoButton.isHidden = true
                 self.appleButton.isHidden = true
                 self.loginView.isHidden = true
+                self.character.isHidden = true
                 // 2. 이 VC로 왔다는 것은 로그인이 필요한 상황 -> identityToken을 통한 Token들 재발급이 필요함
                 DispatchQueue.global(qos: .background).async {
                     

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -176,10 +176,8 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
-
-        let requests = [request, ASAuthorizationPasswordProvider().createRequest()]
-
-        let authorizationController = ASAuthorizationController(authorizationRequests: requests)
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -248,6 +248,8 @@ extension LoginViewController {
             switch response.code {
             case 200..<300:
                 UserDefaults.standard.set(true, forKey: "Signed")
+                UserDefaults.standard.set(true, forKey: "notRegistered")
+                
                 print(UserDefaults.standard.bool(forKey: "Signed"))
                 print("로그인 성공 -> accessToken/refreshToken을 키체인에 저장")
                 
@@ -273,6 +275,8 @@ extension LoginViewController {
             switch response.code {
             case 200..<300:
                 UserDefaults.standard.set(true, forKey: "Signed")
+                UserDefaults.standard.set(true, forKey: "notRegistered")
+
                 print(UserDefaults.standard.bool(forKey: "Signed"))
                 print("로그인 성공 -> accessToken/refreshToken을 키체인에 저장")
                 

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -69,6 +69,7 @@ final class MyFeedViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        emptyView.isHidden = true
         refresh()
     }
     
@@ -137,7 +138,6 @@ final class MyFeedViewController: UIViewController {
         
         alertController.addButton(title: "삭제하기", type: .yellow) { [weak self] in
             self?.deleteMyFeed(idx: idx)
-            self?.deleteCell(path)
         }
         
         present(alertController, animated: true, completion: nil)
@@ -153,16 +153,6 @@ final class MyFeedViewController: UIViewController {
     private func getMoreFeed() {
         self.currentPage += 1
         self.getMyFeed(page: self.currentPage)
-    }
-    
-    func deleteCell(_ path: Int) {
-        var snapshot = dataSource.snapshot()
-        let targetItem = snapshot.itemIdentifiers[path]
-        snapshot.deleteItems([targetItem])
-        dataSource.apply(snapshot)
-        myfeed.remove(at: path)
-        
-        checkEmpty()
     }
     
     @objc private func didTapLeftButton() {

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -140,6 +140,7 @@ final class MyFeedViewController: UIViewController {
         alertController.addButton(title: "삭제하기", type: .yellow) { [weak self] in
             DispatchQueue.global(qos: .userInteractive).async {
                 self?.deleteMyFeed(idx: idx)
+                NotificationCenter.default.post(name: .whenMyfeedDeleteCompleted, object: nil)
             }
             
             self?.deleteCell(path)

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -65,7 +65,6 @@ final class MyFeedViewController: UIViewController {
         register()
         setupDataSource()
         getMyFeed(page: currentPage)
-        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -140,21 +139,12 @@ final class MyFeedViewController: UIViewController {
         alertController.addButton(title: "삭제하기", type: .yellow) { [weak self] in
             DispatchQueue.global(qos: .userInteractive).async {
                 self?.deleteMyFeed(idx: idx)
-                NotificationCenter.default.post(name: .whenMyfeedDeleteCompleted, object: nil)
             }
             
             self?.deleteCell(path)
         }
         
         present(alertController, animated: true, completion: nil)
-    }
-    
-    private func bind() {
-        NotificationCenter.default.publisher(for: .whenDeleteFeedCompleted)
-            .sink(receiveValue: { [weak self] _ in
-                self?.refresh()
-            })
-            .store(in: &bag)
     }
     
     private func refresh() {

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -117,7 +117,6 @@ final class MyFeedViewController: UIViewController {
         alertController.addAction(cancelAction)
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in
             self.showAlert(feedId, item)
-            self.refresh()
         }
         alertController.addAction(deleteAction)
         present(alertController, animated: true, completion: nil)
@@ -137,10 +136,7 @@ final class MyFeedViewController: UIViewController {
         }
         
         alertController.addButton(title: "삭제하기", type: .yellow) { [weak self] in
-            DispatchQueue.global(qos: .userInteractive).async {
-                self?.deleteMyFeed(idx: idx)
-            }
-            
+            self?.deleteMyFeed(idx: idx)
             self?.deleteCell(path)
         }
         
@@ -276,8 +272,10 @@ extension MyFeedViewController {
     }
     
     private func deleteMyFeed(idx: Int) {
-        feedService.deleteMyFeed(idx) { response in
+        feedService.deleteMyFeed(idx) { [weak self] response in
+            guard let self = self else { return }
             response ? self.showToast(.feedDeleteSuccess) : self.showToast(.feedDeleteFail)
+            self.refresh()
         }
     }
     

--- a/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyFeed/ViewController/MyFeedViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김인영 on 2023/07/12.
 //
 
+import Combine
 import UIKit
 
 import DesignSystem
@@ -25,6 +26,8 @@ final class MyFeedViewController: UIViewController {
     private var isEnd: Bool = false
     
     private let emptyView: WIEmptyView = WIEmptyView()
+    
+    private var bag = Set<AnyCancellable>()
     
     // MARK: - UI Components
     
@@ -62,11 +65,12 @@ final class MyFeedViewController: UIViewController {
         register()
         setupDataSource()
         getMyFeed(page: currentPage)
+        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        refresh()
     }
     
     private func setUI() {
@@ -142,6 +146,14 @@ final class MyFeedViewController: UIViewController {
         }
         
         present(alertController, animated: true, completion: nil)
+    }
+    
+    private func bind() {
+        NotificationCenter.default.publisher(for: .whenDeleteFeedCompleted)
+            .sink(receiveValue: { [weak self] _ in
+                self?.refresh()
+            })
+            .store(in: &bag)
     }
     
     private func refresh() {

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -394,7 +394,7 @@ extension MypageViewController {
                 UserDefaults.standard.set(false, forKey: "Signed")
                 
                 DispatchQueue.main.async {
-                    let vc = LoginViewController()
+                    let vc = OnboardingViewController()
                     self.switchRootViewController(rootViewController: vc, animated: true)
                 }
             } else {

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -392,6 +392,7 @@ extension MypageViewController {
                 KeychainManager.shared.delete("refreshToken")
                 
                 UserDefaults.standard.set(false, forKey: "Signed")
+                UserDefaults.standard.set(false, forKey: "notRegistered")
                 
                 DispatchQueue.main.async {
                     let vc = OnboardingViewController()

--- a/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
+++ b/Winey/Winey/Source/Scenes/Nickname/ViewController/NicknameViewController.swift
@@ -273,7 +273,7 @@ class NicknameViewController: UIViewController {
             if response {
                 print("닉네임 등록 성공")
                 if self.viewType.naviExist {
-                    self.dismiss(animated: true)
+                    self.navigationController?.popViewController(animated: true)
                 } else {
                     self.switchRootViewController(rootViewController: TabBarController(), animated: true)
                 }

--- a/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
+++ b/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
@@ -49,8 +49,9 @@ final class SplashViewController: UIViewController {
         
         let refreshToken = KeychainManager.shared.read("refreshToken")
         let notFirstLaunch = UserDefaults.standard.bool(forKey: "notFirstLaunch")
+        let notRegistered = UserDefaults.standard.bool(forKey: "notRegistered")
         
-        if notFirstLaunch {
+        if notFirstLaunch && notRegistered {
             // 로그인 여부에 따라 다른 VC로 이동
             if signed {
                 print("로그인 되어 있음")
@@ -66,12 +67,12 @@ final class SplashViewController: UIViewController {
                             print("토큰 재발급 성공, 로그인이 되어 있으므로 메인 뷰로 이동")
                             // rootViewController = LoginTestViewController()
                             rootViewController = TabBarController()
-                            self.window?.rootViewController = rootViewController
                             // 토큰 재발급 실패 -> 로그인 화면으로 이동
                         case false:
                             print("토큰 재발급 실패, 로그인을 다시 해주세요")
                             rootViewController = LoginViewController()
                         }
+                        self.window?.rootViewController = rootViewController
                     }
                 }
             } else {

--- a/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
+++ b/Winey/Winey/Source/Scenes/Upload/View/ContentsWriteView.swift
@@ -18,9 +18,7 @@ class ContentsWriteView: UIView {
     /// textSendClosure:  선택된 이미지객체를 ViewController로 전달하기 위해 사용되는 클로저
     private let placeholder = "Ex) 버스 타고 가는 길을 운동 삼아 20분 일찍 일어나 걸어갔어요!"
     var textSendClousre: ((_ data: String) -> Void)?
-    
-    var textCountPublisher = PassthroughSubject<(Int, Bool), Never>()
-    
+        
     // MARK: - UI Components
     
     /// textView: 절약 내용을 작성하는 textView
@@ -105,7 +103,6 @@ extension ContentsWriteView: UITextViewDelegate {
             textView.text = nil
         }
         setColor(textView.text.count)
-        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     /// textViewDidEndEditing: 텍스트 뷰의 편집이 종료되었을때의 동작을 정의한 함수
@@ -123,7 +120,6 @@ extension ContentsWriteView: UITextViewDelegate {
             }
         }
         textView.makeBorder(width: 1, color: .winey_gray200)
-        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     /// textViewDidChange: 텍스트 뷰가 편집되었을때의 동작을 정의한 함수
@@ -131,7 +127,6 @@ extension ContentsWriteView: UITextViewDelegate {
         if textView.text.count > 36 { textView.resignFirstResponder() }
         
         textSendClousre?(textView.text ?? "")
-        textCountPublisher.send((textView.text.count, textView.text == placeholder))
     }
     
     func resetContents() {

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -41,8 +41,6 @@ class UploadViewController: UIViewController {
     private let spacing: CGFloat = 24
     
     private var pageGuideSubject = PassthroughSubject<Void, Never>()
-    private var secondPageSubjcet = PassthroughSubject<Void, Never>()
-    private var thirdPageSubject = PassthroughSubject<Void, Never>()
     private var bag = Set<AnyCancellable>()
     
     /// 업로드 단계별로 나타나는 뷰와 커스텀 네비게이션 바 객체 생성
@@ -132,25 +130,6 @@ class UploadViewController: UIViewController {
         pageGuideSubject
             .sink { [weak self] _ in
                 self?.pageGuide.setUI()
-                self?.thirdPage.textContentView.resetPrice()
-            }
-            .store(in: &bag)
-        
-        secondPageSubjcet
-            .sink { [weak self] _ in
-                self?.secondPage.resetContents()
-            }
-            .store(in: &bag)
-        
-        thirdPageSubject
-            .sink { [weak self] _ in
-                self?.thirdPage.textContentView.resetPrice()
-            }
-            .store(in: &bag)
-        
-        secondPage.textCountPublisher
-            .sink { [weak self] (count, result) in
-                self?.textExist = count > 0 && !result ? true : false
             }
             .store(in: &bag)
     }
@@ -317,23 +296,12 @@ class UploadViewController: UIViewController {
         }
     }
     
-    private func deleteContents() {
-        switch stageIdx {
-        case 1:
-            secondPage.resetContents()
-            secondPageSubjcet.send(Void())
-        default:
-            thirdPage.textContentView.resetPrice()
-            thirdPageSubject.send(Void())
-        }
-    }
-    
     // NavigationBar
     /// NavigationBar 상의 버튼을 클릭했을때의 동작을 정의하는 함수
     
     @objc
     private func tapLeftButton() {
-        if isOk || (stageIdx == 1 && textExist){
+        if stageIdx == 0 && isOk {
             let vc = MIPopupViewController(content: .init(
                 title: "지금 나가시면 작성하신 게 지워져요",
                 subtitle: "절약 실천 게시물을 올리시면 레벨업에 가까워져요\n그래도 나가시겠습니까?")
@@ -368,7 +336,6 @@ class UploadViewController: UIViewController {
         
         scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x
                                             - UIScreen.main.bounds.width, y: 0), animated: true)
-        deleteContents()
         stageIdx -= 1
         grayDot.progress -= 1
         grayDot.progress = Double(stageIdx)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#156

👷 **작업한 내용**
- 로그인 후 로딩중화면에 위니 캐릭터 뷰 떠있는 현상 해결
- 전체피드 자기게시물 삭제 -> 마이피드로 가면 게시물 남아있어서 누르면 앱 터짐 현상 해결
- 마이피드 자기게시물 삭제 -> 전체피드로 가면 게시물 남아있어서 누르면 앱 터짐 현상 해결
- 전체피드 자기게시물 삭제 후 셀이 바로 눈앞에서 안없어지는 현상 해결
- 회원탈퇴 후 로그인 뷰로 이동하는 현상 해결 -> 온보딩뷰로 이동하게 수정
- 회원탈퇴 후 앱 껐다 키면 로그인 뷰로 이동하는 현상 -> 온보딩뷰로 이동하게 수정
- 애플로그인 버튼 눌렀을때 애플로그인 진행 안됨 이슈 해결
- 닉네임 수정 후 확인버튼 누르면 앱 터지는 현상 해결
- 피드 업로드 2, 3단계에서 내용이 기록되어있을때 앞으로가기 누르면 알림뜨는 현상 방지
- 피드 업로드 2, 3단계 정보 삭제하는 코드 모두 제거
- 필요없는 코드 제거

## 🚨참고 사항
수정사항 반영 안되어있으면 말해주세요

## 📟 관련 이슈
- Resolved: #156 
