### PR TITLE
[Fix] #159 - 기획/디자인 QA 피드백 반영사항 적용 (응관)

### DIFF
--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextField+Type.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextField+Type.swift
@@ -22,6 +22,7 @@ public struct WITextFieldType {
     public let labelColor: UIColor
     public let activeTextColor: UIColor
     public let activeBorderColor: UIColor
+    public let inactiveTextColor: UIColor
     
     public init(
         textLeftPadding: CGFloat,
@@ -37,7 +38,8 @@ public struct WITextFieldType {
         labelWidth: CGFloat,
         labelColor: UIColor,
         activeTextColor: UIColor,
-        activeBorderColor: UIColor
+        activeBorderColor: UIColor,
+        inactiveTextColor: UIColor
     ) {
         self.textLeftPadding = textLeftPadding
         self.textRightPadding = textRightPadding
@@ -53,6 +55,7 @@ public struct WITextFieldType {
         self.labelColor = labelColor
         self.activeTextColor = activeTextColor
         self.activeBorderColor = activeBorderColor
+        self.inactiveTextColor = inactiveTextColor
     }
 }
 
@@ -72,7 +75,8 @@ public extension WITextFieldType {
         labelWidth: TextField.price.labelWidth,
         labelColor: TextField.price.labelColor,
         activeTextColor: TextField.price.activeTextColor,
-        activeBorderColor: TextField.price.activeBorderColor
+        activeBorderColor: TextField.price.activeBorderColor,
+        inactiveTextColor: TextField.price.inactiveTextColor
     )
     
     static let day: WITextFieldType = WITextFieldType(
@@ -89,7 +93,8 @@ public extension WITextFieldType {
         labelWidth: TextField.day.labelWidth,
         labelColor: TextField.day.labelColor,
         activeTextColor: TextField.day.activeTextColor,
-        activeBorderColor: TextField.day.activeBorderColor
+        activeBorderColor: TextField.day.activeBorderColor,
+        inactiveTextColor: TextField.day.inactiveTextColor
     )
     
     static let nickName: WITextFieldType = WITextFieldType(
@@ -107,7 +112,8 @@ public extension WITextFieldType {
         labelWidth: TextField.nickName.labelWidth,
         labelColor: TextField.nickName.labelColor,
         activeTextColor: TextField.nickName.activeTextColor,
-        activeBorderColor: TextField.nickName.activeBorderColor
+        activeBorderColor: TextField.nickName.activeBorderColor,
+        inactiveTextColor: TextField.nickName.inactiveTextColor
     )
 }
 
@@ -224,6 +230,15 @@ extension WITextFieldType {
                 return .winey_purple400
             case .nickName:
                 return .winey_gray900
+            }
+        }
+        
+        var inactiveTextColor: UIColor {
+            switch self {
+            case .price, .day:
+                return .winey_purple400
+            case .nickName:
+                return .winey_gray500
             }
         }
     }

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
@@ -247,13 +247,15 @@ extension WITextFieldView: UITextFieldDelegate {
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange,
                           replacementString string: String) -> Bool {
         if let text = self.textField.text {
+            
             let newLength = text.count + string.count - range.length
+            
             if type.keyboardType == .default {
-                return !(newLength > type.textLength + 1)
+                return !(newLength > type.textLength + 1) && nameValidation(text: string)
             } else if type.textLength == 11 {
-                return !(newLength > type.textLength + 3)
+                return !(newLength > type.textLength + 3) && nameValidation(text: string)
             } else {
-                return !(newLength > type.textLength)
+                return !(newLength > type.textLength) && nameValidation(text: string)
             }
         }
         return true

--- a/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
+++ b/Winey/Common/DesignSystem/Sources/DesignSystem/Sources/TextField/WITextFieldView.swift
@@ -61,7 +61,7 @@ public final class WITextFieldView: UIView {
         textField.makeBorder(width: Size.borderWidth.rawValue, color: Color.inactiveBorder.color)
         textField.backgroundColor = Color.backgroundColor.color
         textField.font = type.textStyle
-        textField.textColor = Color.inactiveText.color
+        textField.textColor = type.inactiveTextColor
         textField.keyboardType = type.keyboardType
         textField.textAlignment = type.textAlignment
         textField.tintColor = Color.cursorColor.color
@@ -163,7 +163,7 @@ public final class WITextFieldView: UIView {
     
     public func makeInactiveView() {
         textField.makeBorder(width: Size.borderWidth.rawValue, color: Color.inactiveBorder.color)
-        textField.textColor = Color.inactiveText.color
+        textField.textColor = type.inactiveTextColor
     }
     
     public func makeSuccessView() {
@@ -309,7 +309,6 @@ extension WITextFieldView {
     
     enum Color {
         case inactiveBorder
-        case inactiveText
         case activeColor
         case errorTextColor
         case errorBorderColor
@@ -329,8 +328,6 @@ extension WITextFieldView {
                 return .winey_gray900
             case .errorBorderColor:
                 return .winey_red500
-            case .inactiveText:
-                return .winey_gray500
             case .nickNameSuccess:
                 return .winey_blue500
             }

--- a/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
+++ b/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
@@ -8,6 +8,8 @@
 import UIKit
 import KakaoSDKAuth
 
+import DesignSystem
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
@@ -28,5 +30,42 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 _ = AuthController.handleOpenUrl(url: url)
             }
         }
+    }
+    
+    // 앱을 background에서 foreground로 불러올 경우
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let refreshToken = KeychainManager.shared.read("refreshToken") else { return }
+        print("background에서 foreground로 진입")
+        
+        print("리프레쉬 토큰을 통한 액세스 토큰 재발급")
+        LoginService.shared.reissueApple(token: refreshToken) { result in
+            switch result {
+            case true:
+                print("토큰 재발급 성공!")
+            case false:
+                print("refreshToken 만료")
+                print("토큰 재발급 실패 -> LoginView로 변환")
+                guard let windowScene = (scene as? UIWindowScene) else { return }
+                let window = UIWindow(windowScene: windowScene)
+                self.window = window
+                self.setAlert(window)
+            }
+        }
+    }
+    
+    func setAlert(_ window: UIWindow) {
+        let alert = MIPopupViewController(
+            content: .init(
+                title: "세션이 만료되었습니다",
+                subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
+            )
+        )
+        alert.addButton(title: "확인", type: .yellow) {
+            window.rootViewController = LoginViewController()
+            window.makeKeyAndVisible()
+        }
+        window.rootViewController = alert
+        window.makeKeyAndVisible()
+        window.backgroundColor = .winey_gray0
     }
 }

--- a/Winey/Winey/Source/Network/Service/Comment/CommentService.swift
+++ b/Winey/Winey/Source/Network/Service/Comment/CommentService.swift
@@ -10,7 +10,7 @@ import UIKit
 import Moya
 
 final class CommentService {
-    let provider = CustomMoyaProvider<CommentAPI>()
+    let provider = CustomMoyaProvider<CommentAPI>(session: Session(interceptor: SessionInterceptor.shared))
 
     private typealias CreateCommentRes = BaseResponse<CreateCommentResponse>
     

--- a/Winey/Winey/Source/Network/Service/Login/LoginService.swift
+++ b/Winey/Winey/Source/Network/Service/Login/LoginService.swift
@@ -138,17 +138,12 @@ final class LoginService {
                         print(err.localizedDescription)
                     }
                 default:
-                    // 토큰 재발급의 실패 -> 유효기간이 만료되서 -> 저장되있던 토큰들 삭제
-                    do {
-                        KeychainManager.shared.delete("accessToken")
-                        KeychainManager.shared.delete("refreshToken")
-                        print(500)
-                        completion(false)
-                    } catch {
-                        print("token delete error")
-                    }
+                    KeychainManager.shared.delete("accessToken")
+                    KeychainManager.shared.delete("refreshToken")
+                    completion(false)
                 }
             case .failure(let err):
+                print("리프레쉬 토큰 만료")
                 print(err)
             }
         }
@@ -168,7 +163,6 @@ final class LoginService {
 
                     //do something
                     _ = oauthToken
-                    print(oauthToken, "토큰? ")
                     if let oauthToken = oauthToken{
                         completion(oauthToken.accessToken)
                     }
@@ -184,7 +178,6 @@ final class LoginService {
 
                         //do something
                         _ = oauthToken
-                        print(oauthToken, "토큰?")
                         if let oauthToken = oauthToken{
                             completion(oauthToken.accessToken)
                         }

--- a/Winey/Winey/Source/Network/Service/Login/LoginService.swift
+++ b/Winey/Winey/Source/Network/Service/Login/LoginService.swift
@@ -126,8 +126,10 @@ final class LoginService {
                     do {
                         self.reissueResponse = try response.map(ReissueResponse.self)
                         guard let data = self.reissueResponse?.data else { return }
-                        _ = try KeychainManager.shared.updateToken(data.refreshToken, "refreshToken")
-                        _ = try KeychainManager.shared.updateToken(data.accessToken, "accessToken")
+                        
+                        KeychainManager.shared.update(data.refreshToken, "refreshToken")
+                        KeychainManager.shared.update(data.accessToken, "accessToken")
+                        
                         print(data.refreshToken)
                         print(data.accessToken)
                         print(reissueResponse?.message as Any)
@@ -138,8 +140,8 @@ final class LoginService {
                 default:
                     // 토큰 재발급의 실패 -> 유효기간이 만료되서 -> 저장되있던 토큰들 삭제
                     do {
-                        _ = try KeychainManager.shared.deleteToken("accessToken")
-                        _ = try KeychainManager.shared.deleteToken("refreshToken")
+                        KeychainManager.shared.delete("accessToken")
+                        KeychainManager.shared.delete("refreshToken")
                         print(500)
                         completion(false)
                     } catch {

--- a/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
+++ b/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
@@ -6,10 +6,7 @@
 //
 
 import Foundation
-import UIKit
 
-import Alamofire
-import DesignSystem
 import Moya
 
 final class SessionInterceptor: RequestInterceptor {
@@ -17,9 +14,9 @@ final class SessionInterceptor: RequestInterceptor {
     static let shared = SessionInterceptor()
     
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        guard urlRequest.url?.absoluteString.hasPrefix(URLConstant.baseURL) == true, 
-              let accessToken = KeychainManager.shared.read("accessToken"),
-              let refreshToken = KeychainManager.shared.read("refreshToken")
+        guard urlRequest.url?.absoluteString.hasPrefix(URLConstant.baseURL) == true,
+            let accessToken = KeychainManager.shared.read("accessToken"),
+            let refreshToken = KeychainManager.shared.read("refreshToken")
         else {
             completion(.success(urlRequest))
             return
@@ -31,55 +28,4 @@ final class SessionInterceptor: RequestInterceptor {
         print("adaptor 적용 \(urlRequest.headers)")
         completion(.success(urlRequest))
     }
-
-    
-//    // 토큰 만료시에 400 오류가 떴을때 재통신을 하게끔 도와주는 retry 함수
-//     func retry(_ request: Request, for session: Session,
-//               dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-//        print("retry")
-//        guard let response = request.task?.response as? HTTPURLResponse,
-//              response.statusCode >= 400
-//        else {
-//            completion(.doNotRetryWithError(error))
-//            return
-//        }
-//        print(request.task?.currentRequest?.headers)
-//        print(response.statusCode)
-//
-//        // 엑세스 만료 -> 400오류가 돌아오니까 -> 토큰 업데이트 후 -> retry
-//        // 앱 사용하던 중 accessToken이 만료되었다면? -> 통신오류 -> 토큰 재발급을 통해 accessToken 갱신해줘야함
-//        // 해당 retry 메서드의 사용빈도 최소화를 위해 splashView가 끝난 시점에서 항상 토큰 갱신을 진행한다!
-//         guard let refreshToken = KeychainManager.shared.read("refreshToken") else { return }
-//         print(refreshToken)
-//
-//             print("리프레쉬 토큰을 통한 액세스 토큰 재발급")
-//             LoginService.shared.reissueApple(token: refreshToken) { result in
-//                 switch result {
-//                 case true:
-//                     print("토큰 재발급 성공!")
-//                     completion(.retry)
-//                 case false:
-//                     completion(.doNotRetry)
-//                 }
-//             }
-//         // }
-////    else {
-////             print("2트 - 스플래쉬 뷰 부터 다시 시작")
-////
-////             if let vc = UIApplication.shared.windows.filter({$0.isKeyWindow}).first as? UIViewController {
-////                 let alert = MIPopupViewController(
-////                    content: .init(
-////                        title: "세션이 만료되었습니다",
-////                        subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
-////                    )
-////                 )
-////                 alert.addButton(title: "확인", type: .yellow) {
-////                     UIApplication.shared.windows.filter{$0.isKeyWindow}.first?.rootViewController = LoginViewController()
-////                 }
-////                 vc.present(alert, animated: true, completion: nil)
-////             }
-////
-////             completion(.doNotRetry)
-////         }
-//    }
 }

--- a/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
+++ b/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
@@ -33,53 +33,53 @@ final class SessionInterceptor: RequestInterceptor {
     }
 
     
-    // 토큰 만료시에 400 오류가 떴을때 재통신을 하게끔 도와주는 retry 함수
-     func retry(_ request: Request, for session: Session,
-               dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-        print("retry")
-        guard let response = request.task?.response as? HTTPURLResponse,
-              response.statusCode >= 400
-        else {
-            completion(.doNotRetryWithError(error))
-            return
-        }
-        print(request.task?.currentRequest?.headers)
-        print(response.statusCode)
-
-        // 엑세스 만료 -> 400오류가 돌아오니까 -> 토큰 업데이트 후 -> retry
-        // 앱 사용하던 중 accessToken이 만료되었다면? -> 통신오류 -> 토큰 재발급을 통해 accessToken 갱신해줘야함
-        // 해당 retry 메서드의 사용빈도 최소화를 위해 splashView가 끝난 시점에서 항상 토큰 갱신을 진행한다!
-         guard let refreshToken = KeychainManager.shared.read("refreshToken") else { return }
-         print(refreshToken)
-
-             print("리프레쉬 토큰을 통한 액세스 토큰 재발급")
-             LoginService.shared.reissueApple(token: refreshToken) { result in
-                 switch result {
-                 case true:
-                     print("토큰 재발급 성공!")
-                     completion(.retry)
-                 case false:
-                     completion(.doNotRetry)
-                 }
-             }
-         // }
-//    else {
-//             print("2트 - 스플래쉬 뷰 부터 다시 시작")
+//    // 토큰 만료시에 400 오류가 떴을때 재통신을 하게끔 도와주는 retry 함수
+//     func retry(_ request: Request, for session: Session,
+//               dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+//        print("retry")
+//        guard let response = request.task?.response as? HTTPURLResponse,
+//              response.statusCode >= 400
+//        else {
+//            completion(.doNotRetryWithError(error))
+//            return
+//        }
+//        print(request.task?.currentRequest?.headers)
+//        print(response.statusCode)
 //
-//             if let vc = UIApplication.shared.windows.filter({$0.isKeyWindow}).first as? UIViewController {
-//                 let alert = MIPopupViewController(
-//                    content: .init(
-//                        title: "세션이 만료되었습니다",
-//                        subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
-//                    )
-//                 )
-//                 alert.addButton(title: "확인", type: .yellow) {
-//                     UIApplication.shared.windows.filter{$0.isKeyWindow}.first?.rootViewController = LoginViewController()
+//        // 엑세스 만료 -> 400오류가 돌아오니까 -> 토큰 업데이트 후 -> retry
+//        // 앱 사용하던 중 accessToken이 만료되었다면? -> 통신오류 -> 토큰 재발급을 통해 accessToken 갱신해줘야함
+//        // 해당 retry 메서드의 사용빈도 최소화를 위해 splashView가 끝난 시점에서 항상 토큰 갱신을 진행한다!
+//         guard let refreshToken = KeychainManager.shared.read("refreshToken") else { return }
+//         print(refreshToken)
+//
+//             print("리프레쉬 토큰을 통한 액세스 토큰 재발급")
+//             LoginService.shared.reissueApple(token: refreshToken) { result in
+//                 switch result {
+//                 case true:
+//                     print("토큰 재발급 성공!")
+//                     completion(.retry)
+//                 case false:
+//                     completion(.doNotRetry)
 //                 }
-//                 vc.present(alert, animated: true, completion: nil)
 //             }
-//
-//             completion(.doNotRetry)
-//         }
-    }
+//         // }
+////    else {
+////             print("2트 - 스플래쉬 뷰 부터 다시 시작")
+////
+////             if let vc = UIApplication.shared.windows.filter({$0.isKeyWindow}).first as? UIViewController {
+////                 let alert = MIPopupViewController(
+////                    content: .init(
+////                        title: "세션이 만료되었습니다",
+////                        subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
+////                    )
+////                 )
+////                 alert.addButton(title: "확인", type: .yellow) {
+////                     UIApplication.shared.windows.filter{$0.isKeyWindow}.first?.rootViewController = LoginViewController()
+////                 }
+////                 vc.present(alert, animated: true, completion: nil)
+////             }
+////
+////             completion(.doNotRetry)
+////         }
+//    }
 }

--- a/Winey/Winey/Source/Network/Service/Nickname/NicknameService.swift
+++ b/Winey/Winey/Source/Network/Service/Nickname/NicknameService.swift
@@ -22,6 +22,7 @@ final class NicknameService {
             case .success(let response):
                 switch response.statusCode {
                 case 200..<300:
+                    UserSingleton.saveNickname(nickname)
                     completion(true)
                 default:
                     completion(false)

--- a/Winey/Winey/Source/Network/Service/Notification/NotificationService.swift
+++ b/Winey/Winey/Source/Network/Service/Notification/NotificationService.swift
@@ -30,7 +30,7 @@ final class NotificationService {
             case .success(let response):
                 do {
                     self.totalNotificationData = try response.map(BaseResponse<TotalNotificationResponse>.self)
-                    print("❤️❤️❤️❤️❤️❤️❤️", totalNotificationData)
+                    // print("❤️❤️❤️❤️❤️❤️❤️", totalNotificationData)
                     completion(totalNotificationData)
                 } catch let error {
                     print(error.localizedDescription, 500)

--- a/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
+++ b/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
@@ -176,8 +176,7 @@ extension AlertViewController {
     }
     
     private func checkAllNotification() {
-        alertService.patchAllNotification() { [weak self] response in
-            guard let self = self else { return } // Unwrap self
+        alertService.patchAllNotification() { response in
             
             switch response?.code {
             case .some(200..<300): // Changed the pattern matching here

--- a/Winey/Winey/Source/Scenes/Detail/DetailViewController.swift
+++ b/Winey/Winey/Source/Scenes/Detail/DetailViewController.swift
@@ -388,6 +388,7 @@ extension DetailViewController {
             self.applyNewComment(item: newCommentItem)
             
             self.commentCount += 1
+            fetchFeedDetail()
         }
     }
     

--- a/Winey/Winey/Source/Scenes/Detail/DetailViewController.swift
+++ b/Winey/Winey/Source/Scenes/Detail/DetailViewController.swift
@@ -89,6 +89,7 @@ extension DetailViewController {
         tableView.registerCell(DetailInfoCell.self)
         tableView.registerCell(EmptyCommentCell.self)
         tableView.contentInsetAdjustmentBehavior = .never
+        tableView.backgroundColor = .winey_gray50
         // TODO: 키보드 내리는 동작 UX 개선
         tableView.keyboardDismissMode = .interactive
         naviBar.leftButton.addTarget(self, action: #selector(didTapNaviBarLeftButton), for: .touchUpInside)

--- a/Winey/Winey/Source/Scenes/Detail/Views/EmptyCommentCell.swift
+++ b/Winey/Winey/Source/Scenes/Detail/Views/EmptyCommentCell.swift
@@ -29,7 +29,7 @@ final class EmptyCommentCell: UITableViewCell {
 extension EmptyCommentCell {
     func setupAttribute() {
         self.emptyImageView.image = .Icon.empty_comment
-        self.backgroundColor = .winey_gray100
+        self.backgroundColor = .winey_gray50
         self.emptyLabel.setText(
             "아직 댓글이 없어요",
             attributes: .init(

--- a/Winey/Winey/Source/Scenes/Detail/Views/FloatingCommentTextView.swift
+++ b/Winey/Winey/Source/Scenes/Detail/Views/FloatingCommentTextView.swift
@@ -153,7 +153,7 @@ extension FloatingCommentTextView: UITextViewDelegate {
 extension FloatingCommentTextView {
     enum Const {
         static let maxLineCount: Int = 4
-        static let minimumWarningCount: Int = 100
+        static let minimumWarningCount: Int = 450
         static let maximumLimitCount: Int = 500
         static let minimumViewHeight: CGFloat = 22
         static let textInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)

--- a/Winey/Winey/Source/Scenes/Detail/Views/FloatingCommentView.swift
+++ b/Winey/Winey/Source/Scenes/Detail/Views/FloatingCommentView.swift
@@ -132,7 +132,7 @@ extension FloatingCommentView {
         static let limitAttributes = Typography.Attributes(
             style: .detail3,
             weight: .medium,
-            textColor: .red
+            textColor: .winey_red500
         )
     }
 }

--- a/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
+++ b/Winey/Winey/Source/Scenes/Feed/ViewController/FeedViewController.swift
@@ -273,7 +273,7 @@ final class FeedViewController: UIViewController {
                 AmplitudeManager.logEvent(event: logEvent)
             }
             
-            warningViewController.addButton(title: "목표 설정하러가기", type: .yellow) {
+            warningViewController.addButton(title: "설정하기", type: .yellow) {
                 self.tabBarController?.selectedIndex = 2
                 let logEvent = LogEventImpl(category: .click_goalsetting, parameters: ["method": true])
                 AmplitudeManager.logEvent(event: logEvent)

--- a/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
+++ b/Winey/Winey/Source/Scenes/Login/ViewController/LoginViewController.swift
@@ -247,6 +247,7 @@ extension LoginViewController {
             case 200..<300:
                 UserDefaults.standard.set(true, forKey: "Signed")
                 UserDefaults.standard.set(true, forKey: "notRegistered")
+                UserDefaults.standard.set("APPLE", forKey: "loginType")
                 
                 print(UserDefaults.standard.bool(forKey: "Signed"))
                 print("로그인 성공 -> accessToken/refreshToken을 키체인에 저장")
@@ -274,6 +275,7 @@ extension LoginViewController {
             case 200..<300:
                 UserDefaults.standard.set(true, forKey: "Signed")
                 UserDefaults.standard.set(true, forKey: "notRegistered")
+                UserDefaults.standard.set("KAKAO", forKey: "loginType")
 
                 print(UserDefaults.standard.bool(forKey: "Signed"))
                 print("로그인 성공 -> accessToken/refreshToken을 키체인에 저장")

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -394,6 +394,10 @@ extension MypageViewController {
                 UserDefaults.standard.set(false, forKey: "Signed")
                 UserDefaults.standard.set(false, forKey: "notRegistered")
                 
+                if UserDefaults.standard.string(forKey: "loginType") == "KAKAO" {
+                    self.loginService.kakaoLogOut()
+                }
+                
                 DispatchQueue.main.async {
                     let vc = OnboardingViewController()
                     self.switchRootViewController(rootViewController: vc, animated: true)
@@ -411,6 +415,10 @@ extension MypageViewController {
                 KeychainManager.shared.delete("refreshToken")
                 
                 UserDefaults.standard.set(false, forKey: "Signed")
+                
+                if UserDefaults.standard.string(forKey: "loginType") == "KAKAO" {
+                    self.loginService.kakaoLogOut()
+                }
                 
                 DispatchQueue.main.async {
                     let vc = LoginViewController()

--- a/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/ViewControllers/MypageViewController.swift
@@ -190,6 +190,8 @@ extension MypageViewController: UICollectionViewDataSource {
             if isOver {
                 duringGoalCount = nil
                 duringGoalAmount = nil
+                targetMoney = nil
+                dday = nil
             }
             mypageGoalInfoCell.configure(
                 model: .init(

--- a/Winey/Winey/Source/Scenes/MyPage/Views/Cells/MypageGoalInfoCell.swift
+++ b/Winey/Winey/Source/Scenes/MyPage/Views/Cells/MypageGoalInfoCell.swift
@@ -32,6 +32,8 @@ final class MypageGoalInfoCell: UICollectionViewCell {
     var blockAlertTappedClosure: (() -> Void)?
     
     private var dday: String = ""
+    private var goalAmount: String = "0"
+    private var target: String = "0"
     
     // MARK: - UIComponents
     
@@ -221,7 +223,7 @@ final class MypageGoalInfoCell: UICollectionViewCell {
     
     @objc
     private func modifyButtonTapped() {
-        ["아직 없어요", "D-0"].contains(dday) ? self.saveGoalButtonTappedClosure?() : self.blockAlertTappedClosure?()
+        ["아직 없어요", "D-0"].contains(dday) || goalAmount >= target ? self.saveGoalButtonTappedClosure?() : self.blockAlertTappedClosure?()
     }
     
     // MARK: - View Life Cycle
@@ -238,7 +240,8 @@ final class MypageGoalInfoCell: UICollectionViewCell {
     }
     
     func configure(model: ViewModel) {
-        let goalAmount = model.duringGoalAmount?.addCommaToString() ?? "0"
+        goalAmount = model.duringGoalAmount?.addCommaToString() ?? "0"
+        
         accumulatedWineyLabel.setText(
             "\(goalAmount)원",
             attributes: .init(
@@ -256,10 +259,11 @@ final class MypageGoalInfoCell: UICollectionViewCell {
                 textColor: .winey_gray900
             )
         )
+        
         if let targetMoney = model.targetMoney {
-            let money = targetMoney.addCommaToString() ?? "0"
+            target = targetMoney.addCommaToString() ?? "0"
             goalLabel.setText(
-                "\(money)원",
+                "\(target)원",
                 attributes: .init(
                     style: .headLine4,
                     weight: .bold,

--- a/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
+++ b/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
@@ -45,9 +45,8 @@ final class SplashViewController: UIViewController {
     @objc private func didFinishSplash() {
         
         var rootViewController = UIViewController()
-        let signed = UserDefaults.standard.bool(forKey: "Signed")
         
-        let refreshToken = KeychainManager.shared.read("refreshToken")
+        let signed = UserDefaults.standard.bool(forKey: "Signed")
         let notFirstLaunch = UserDefaults.standard.bool(forKey: "notFirstLaunch")
         let notRegistered = UserDefaults.standard.bool(forKey: "notRegistered")
         

--- a/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
+++ b/Winey/Winey/Source/Scenes/Splash/SplashViewController.swift
@@ -56,25 +56,8 @@ final class SplashViewController: UIViewController {
             if signed {
                 print("로그인 되어 있음")
                 // 로그인이 되어 있다면 로그인 후의 화면으로 진입
-                // 이와 동시에 refreshToken을 활용한 accessToken/refreshToken 업데이트!
-                print("리프레쉬(나한텐 액세스) 토큰 유효")
-                print(refreshToken! as String)
-                DispatchQueue.main.async {
-                    LoginService.shared.reissueApple(token: refreshToken! as String) { result in
-                        switch result {
-                            // 토큰 재발급 성공 -> 로그인 후의 화면으로
-                        case true:
-                            print("토큰 재발급 성공, 로그인이 되어 있으므로 메인 뷰로 이동")
-                            // rootViewController = LoginTestViewController()
-                            rootViewController = TabBarController()
-                            // 토큰 재발급 실패 -> 로그인 화면으로 이동
-                        case false:
-                            print("토큰 재발급 실패, 로그인을 다시 해주세요")
-                            rootViewController = LoginViewController()
-                        }
-                        self.window?.rootViewController = rootViewController
-                    }
-                }
+                rootViewController = TabBarController()
+                self.window?.rootViewController = rootViewController
             } else {
                 print("로그인이 되어 있지 않음")
                 rootViewController = LoginViewController()

--- a/Winey/Winey/Source/Scenes/TabBar/TabBarController.swift
+++ b/Winey/Winey/Source/Scenes/TabBar/TabBarController.swift
@@ -83,9 +83,8 @@ extension TabBarController {
 
 extension TabBarController {
     private func getUser() {
-        userService.getTotalUser() { [weak self] response in
+        userService.getTotalUser() { response in
             guard let response, let data = response.data else { return }
-            guard let self else { return }
             
             // TODO: 레벨정보가 필요하다면 이곳에서 저장하고 사용합니다. 이것도 임시 구현 (시간 이슈)
             let hasGoal = data.userResponseGoalDto != nil

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -24,9 +24,7 @@ class UploadViewController: UIViewController {
             setUI()
             setButtonActivate(stageIdx)
             
-            if stageIdx != 0 {
-                setAddTarget()
-            }
+            if stageIdx != 0 { setAddTarget() }
         }
     }
     
@@ -142,7 +140,7 @@ class UploadViewController: UIViewController {
         
         imagePicker.delegate = self
         
-        nextButton.setTitle("확인", for: .normal)
+        nextButton.setTitle(stageIdx == 2 ? "업로드" : "다음", for: .normal)
         
         /// 업로드 뷰 단계에 따라서 네비게이션바 좌측 버튼에 다른 이미지가 들어가도록 함
         switch stageIdx {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#159

👷 **작업한 내용**
- 앱이 background에서 foreground로 진입할때마다 토큰 재발급 로직 실행되는 코드 추가
- 인터셉터 retry 함수 주석처리
- 목표설정 이동 버튼 라이팅 수정
- 텍스트필드 비활성화시 text 색상 수정
- 업로드 3단계에서 하단 버튼 라이팅 수정
- 특수문자/이모티콘 텍스트필드 입력 방지 코드 추가
- 댓글 방지 붉은 텍스트 색상 변경
- 댓글 무한 스크롤 방지 경고 텍스트 450자부터 표시되도록 변경
- 키체인 CRUD 함수 관련 코드 개선
- 로그인 시에 카카오/애플 중 어떤 소셜로그인인지 UserDefaults에 저장하는 코드추가
-  현재 카카오계정을 기반으로 로그인된 상태라면 로그아웃/회원탈퇴시에 kakaoLogOut 함수 실행되게끔 코드 추가
- 아직 댓글이 없어요 배경색 winey_gray50으로 수정
- 피드 디테일뷰 백그라운드색 gray50으로 수정
- 댓글 업로드 후 피드상세뷰 한번 refresh 해주게끔 수정 (닉네임 수정 후 댓글작성하면, 수정된 닉네임으로 안올라감 이슈 해결)
- 닉네임 수정하고 앱을 안끈상태에서 자신의 댓글을 삭제하고싶은데, 신고하기가 뜨는 오류 해결 (UserSingleton에 바뀐 닉네임 저장하여 해결)
- 스플래쉬뷰 끝나고 토큰 재발급 받는 로직 삭제 -> 앱이 foreground로 들어올때마다 발급받도록 변경
- 절약기간 남았는데 -> 절약 목표 달성시에 절약설정 뷰로 들어갈 수 있게끔 로직 수정
- 절약기간 지났는데 -> 절약 목표 금액 그대로 남아있고, 절약기간 디데이 음수로 뜨는 에러 수정 

## 🚨참고 사항
적용 안되거나 이상한부분 언제든 알려주세요

## 📟 관련 이슈
- Resolved: #159 