### PR TITLE
[Fix] #177 - 릴리즈 이전 코드 기능 점검

### DIFF
--- a/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
+++ b/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
@@ -157,8 +157,6 @@ extension AlertViewController {
             }
             
             self?.model = newArray
-            
-            self?.refreshControl.endRefreshing()
             print("😀", data)
         }
     }

--- a/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
+++ b/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
@@ -177,7 +177,7 @@ extension AlertViewController {
         case "RANKUPTO2", "RANKUPTO3", "RANKUPTO4",
             "DELETERANKDOWNTO1", "DELETERANKDOWNTO2", "DELETERANKDOWNTO3", "GOALFAILED":
             let mypageViewController = MypageViewController()
-            mypageViewController.navigationBar.isHidden = false
+            mypageViewController.navigationBar = WINavigationBar(leftBarItem: .back, title: "마이페이지")
             navigationController?.pushViewController(mypageViewController, animated: true)
             
         default:


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#177

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
 - [x] 알림에서 마이페이지 이동 시, 상단 네비게이션 바에 뒤로가기 버튼 추가
 - [x] 좋아요 혹은 댓글 달린 게시글 삭제 시, 관련 알림 삭제 문제 야기하는 코드 제거

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
릴리즈 이전 서버에서 최신 DB로 코드를 바꾼다고 하니, 클라이언트 마감 후 **병합이 이뤄졌을 때 알림 쪽, 피드 쪽 재차 점검해볼 필요**가 있습니다.
 
현 시점, 서버의 코드개선이 되지않은 DB 사용으로 인해, 피드와 알림 쪽에 무한로딩 걸리는 버그현상이 있더라구요!

cf) GIF에서 보이는 알림 누적현상은, 서버측의 바뀌기 이전 DB의 내용이니 일시적인 현상입니다.

## 📸 스크린샷
|GIF|
|:-
![Simulator Screen Recording - iPhone 14 Pro - 2023-09-06 at 03 04 13](https://github.com/team-winey/Winey-iOS/assets/105866831/c56141aa-2e3e-45b6-b2d1-4c564538d1b6)


## 📟 관련 이슈
- Resolved: #177 
