### PR TITLE
[Feat] #143 토큰 만료 로직에 인터셉터 적용

### DIFF
--- a/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
+++ b/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
@@ -49,26 +49,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 guard let windowScene = (scene as? UIWindowScene) else { return }
                 let window = UIWindow(windowScene: windowScene)
                 self.window = window
-                self.setAlert(window)
             }
         }
         
         NotificationCenter.default.post(name: .whenEnterForeground, object: nil)
-    }
-    
-    func setAlert(_ window: UIWindow) {
-        let alert = MIPopupViewController(
-            content: .init(
-                title: "세션이 만료되었습니다",
-                subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
-            )
-        )
-        alert.addButton(title: "확인", type: .yellow) {
-            window.rootViewController = LoginViewController()
-            window.makeKeyAndVisible()
-        }
-        window.rootViewController = alert
-        window.makeKeyAndVisible()
-        window.backgroundColor = .winey_gray0
     }
 }

--- a/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
+++ b/Winey/Winey/Source/Global/Supports/SceneDelegate.swift
@@ -40,9 +40,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         print("리프레쉬 토큰을 통한 액세스 토큰 재발급")
         LoginService.shared.reissueApple(token: refreshToken) { result in
             switch result {
-            case true:
+            case .success:
                 print("토큰 재발급 성공!")
-            case false:
+            case .failure(let error):
+                print(error)
                 print("refreshToken 만료")
                 print("토큰 재발급 실패 -> LoginView로 변환")
                 guard let windowScene = (scene as? UIWindowScene) else { return }

--- a/Winey/Winey/Source/Network/Base/CustomMoyaProvider.swift
+++ b/Winey/Winey/Source/Network/Base/CustomMoyaProvider.swift
@@ -12,6 +12,9 @@ import Moya
 class CustomMoyaProvider<Target: TargetType>: MoyaProvider<Target> {
     convenience init() {
         let plugins: [PluginType] = [MoyaLoggerPlugin()]
-        self.init(plugins: plugins)
+        let session = Session(interceptor: SessionInterceptor())
+        session.sessionConfiguration.timeoutIntervalForRequest = 10
+        
+        self.init(session: session, plugins: plugins)
     }
 }

--- a/Winey/Winey/Source/Network/Service/Comment/CommentService.swift
+++ b/Winey/Winey/Source/Network/Service/Comment/CommentService.swift
@@ -10,7 +10,7 @@ import UIKit
 import Moya
 
 final class CommentService {
-    let provider = CustomMoyaProvider<CommentAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let provider = CustomMoyaProvider<CommentAPI>()
 
     private typealias CreateCommentRes = BaseResponse<CreateCommentResponse>
     
@@ -23,6 +23,7 @@ final class CommentService {
                     else { throw CommentNetworkError.undefined }
                     continuation.resume(returning: response)
                 } catch {
+                    LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                     continuation.resume(throwing: CommentNetworkError.undefined)
                 }
             }
@@ -38,6 +39,7 @@ final class CommentService {
                     // continuation.resume(returning: Void())
                     continuation.resume(returning: true)
                 } catch {
+                    LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                     continuation.resume(throwing: CommentNetworkError.undefined)
                 }
             }

--- a/Winey/Winey/Source/Network/Service/Feed/FeedService.swift
+++ b/Winey/Winey/Source/Network/Service/Feed/FeedService.swift
@@ -13,7 +13,7 @@ import Moya
 
 final class FeedService {
     
-    let feedProvider = CustomMoyaProvider<FeedAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let feedProvider = CustomMoyaProvider<FeedAPI>()
     
     init() { }
     
@@ -32,6 +32,7 @@ final class FeedService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }
@@ -50,6 +51,7 @@ final class FeedService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }
@@ -87,6 +89,7 @@ final class FeedService {
                     completionHandler(false)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
                 completionHandler(false)
             }
@@ -114,6 +117,7 @@ final class FeedService {
                     else { throw FeedNetworkError.undefined }
                     continuation.resume(returning: response)
                 } catch {
+                    LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                     continuation.resume(throwing: FeedNetworkError.undefined)
                 }
             }

--- a/Winey/Winey/Source/Network/Service/FeedLike/FeedLikeService.swift
+++ b/Winey/Winey/Source/Network/Service/FeedLike/FeedLikeService.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class FeedLikeService {
     
-    let feedLikeProvider = CustomMoyaProvider<FeedLikeAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let feedLikeProvider = CustomMoyaProvider<FeedLikeAPI>()
     
     init() { }
     
@@ -30,6 +30,7 @@ final class FeedLikeService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }

--- a/Winey/Winey/Source/Network/Service/Goal/GoalService.swift
+++ b/Winey/Winey/Source/Network/Service/Goal/GoalService.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class GoalService {
     
-    let goalProvider = CustomMoyaProvider<GoalAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let goalProvider = CustomMoyaProvider<GoalAPI>()
     
     init() { }
     
@@ -30,6 +30,7 @@ final class GoalService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }

--- a/Winey/Winey/Source/Network/Service/Login/LoginService.swift
+++ b/Winey/Winey/Source/Network/Service/Login/LoginService.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 import Alamofire
+import DesignSystem
 import Moya
 import KakaoSDKAuth
 import KakaoSDKUser
@@ -156,13 +157,30 @@ final class LoginService {
                 // 로그아웃 처리
                 UserDefaults.standard.set(false, forKey: "Signed")
 
-                // 루트 뷰 교체
-                UIViewController().switchRootViewController(rootViewController: LoginViewController(), animated: true)
+                // 세션 만료 alert 창으로 루트뷰 전환
+                setSessionExpireAlert()
+                
                 print(err)
                 
                 completion(.failure(.networkError))
             }
         }
+    }
+    
+    func setSessionExpireAlert() {
+        let alert = MIPopupViewController(
+            content: .init(
+                title: "세션이 만료되었습니다",
+                subtitle: "확인 버튼을 눌러서 다시 로그인을 진행해주세요"
+            )
+        )
+        alert.addButton(title: "확인", type: .yellow) {
+            UIViewController().switchRootViewController(rootViewController: LoginViewController(), animated: true)
+        }
+        
+        let vc = UIViewController()
+        vc.view.backgroundColor = .winey_gray50
+        vc.switchRootViewController(rootViewController: alert, animated: true)
     }
     
     // MARK: - 로그인

--- a/Winey/Winey/Source/Network/Service/Login/LoginService.swift
+++ b/Winey/Winey/Source/Network/Service/Login/LoginService.swift
@@ -8,14 +8,15 @@
 import Foundation
 import UIKit
 
+import Alamofire
 import Moya
 import KakaoSDKAuth
 import KakaoSDKUser
 
 
 final class LoginService {
-    
-    let authProvider = CustomMoyaProvider<LoginAPI>(session: Session(interceptor: SessionInterceptor.shared))
+
+    let authProvider = MoyaProvider<LoginAPI>()
     
     static let shared = LoginService()
     
@@ -25,6 +26,10 @@ final class LoginService {
     private(set) var logoutResponse: LogoutResponse?
     private(set) var reissueResponse: ReissueResponse?
     
+    enum WineyError: Error {
+        case networkError
+        case tokenError
+    }
     
     func loginWithKakao(request: LoginRequest, token: String,
                         completion: @escaping ((LoginResponse?) -> Void)) {
@@ -96,7 +101,7 @@ final class LoginService {
     }
     
     // 3. 애플 회원탈퇴
-    
+
     func withdrawApple(token: String, _ completion: @escaping ((Bool) -> Void)) {
         authProvider.request(.appleWithdraw(token: token)) { result in
             switch result {
@@ -117,7 +122,7 @@ final class LoginService {
     
     // 4. 애플 토큰 재발급
     
-    func reissueApple(token: String, _ completion: @escaping ((Bool) -> (Void))) {
+    func reissueApple(token: String, _ completion: @escaping (Result<Bool, WineyError>) -> (Void)) {
         authProvider.request(.reissueToken(token: token)) { [self] result in
             print(result)
             switch result {
@@ -134,13 +139,12 @@ final class LoginService {
                         print(data.refreshToken)
                         print(data.accessToken)
                         print(reissueResponse?.message as Any)
-                        completion(true)
-                    } catch(let err) {
-                        print(err.localizedDescription)
+                        completion(.success(true))
+                    } catch {
+                        completion(.failure(.networkError))
                     }
                 default:
                     print("network issue")
-                    completion(false)
                 }
             case .failure(let err):
                 print("리프레쉬 토큰 만료 -> 만료 로직 실행")
@@ -148,13 +152,15 @@ final class LoginService {
                 // 토큰 삭제
                 KeychainManager.shared.delete("accessToken")
                 KeychainManager.shared.delete("refreshToken")
-                
+
                 // 로그아웃 처리
                 UserDefaults.standard.set(false, forKey: "Signed")
-                
+
                 // 루트 뷰 교체
                 UIViewController().switchRootViewController(rootViewController: LoginViewController(), animated: true)
                 print(err)
+                
+                completion(.failure(.networkError))
             }
         }
     }

--- a/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
+++ b/Winey/Winey/Source/Network/Service/Login/SessionInterceptor.swift
@@ -5,13 +5,15 @@
 //  Created by 김응관 on 2023/08/09.
 //
 
+import Combine
 import Foundation
 
+import Alamofire
+import DesignSystem
 import Moya
+import UIKit
 
 final class SessionInterceptor: RequestInterceptor {
-    
-    static let shared = SessionInterceptor()
     
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         guard urlRequest.url?.absoluteString.hasPrefix(URLConstant.baseURL) == true,
@@ -28,4 +30,30 @@ final class SessionInterceptor: RequestInterceptor {
         print("adaptor 적용 \(urlRequest.headers)")
         completion(.success(urlRequest))
     }
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        print("retry 진입")
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode >= 400 else {
+            dump(error)
+            completion(.doNotRetryWithError(error))
+            return
+        }
+
+        guard let refreshToken = KeychainManager.shared.read("refreshToken") else { return }
+
+        LoginService.shared.reissueApple(token: refreshToken) { result in
+            switch result {
+            case .success:
+                print("Retry-토큰 재발급 성공")
+                completion(.retry)
+            case .failure(let error):
+                completion(.doNotRetryWithError(error))
+                return
+            }
+        }
+    }
 }
+
+
+
+

--- a/Winey/Winey/Source/Network/Service/Nickname/NicknameService.swift
+++ b/Winey/Winey/Source/Network/Service/Nickname/NicknameService.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 final class NicknameService {
-    let nickNameprovider = CustomMoyaProvider<NicknameAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let nickNameprovider = CustomMoyaProvider<NicknameAPI>()
     
     private var duplicateResponse: DuplicateCheckResponse?
     
@@ -28,6 +28,7 @@ final class NicknameService {
                     completion(false)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }
@@ -51,6 +52,7 @@ final class NicknameService {
                     print("error")
                 }
             case .failure(let error):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(error.localizedDescription)
             }
         }

--- a/Winey/Winey/Source/Network/Service/Notification/NotificationService.swift
+++ b/Winey/Winey/Source/Network/Service/Notification/NotificationService.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 final class NotificationService {
-    let notificationProvider = CustomMoyaProvider<NotificationAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let notificationProvider = CustomMoyaProvider<NotificationAPI>()
 
     init() { }
 
@@ -36,6 +36,9 @@ final class NotificationService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in
+                    self.getTotalNotification { _ in }
+                }
                 print(err)
             }
         }
@@ -58,6 +61,7 @@ final class NotificationService {
                     completion(false)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
                 completion(false)
             }
@@ -83,6 +87,7 @@ final class NotificationService {
                     print("error")
                 }
             case .failure(let error):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(error.localizedDescription)
             }
         }

--- a/Winey/Winey/Source/Network/Service/Recommend/RecommendService.swift
+++ b/Winey/Winey/Source/Network/Service/Recommend/RecommendService.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class RecommendService {
     
-    let recommendProvider = CustomMoyaProvider<RecommendAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let recommendProvider = CustomMoyaProvider<RecommendAPI>(session: Session(interceptor: SessionInterceptor()))
     
     init() {}
     
@@ -30,6 +30,7 @@ final class RecommendService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }

--- a/Winey/Winey/Source/Network/Service/User/UserService.swift
+++ b/Winey/Winey/Source/Network/Service/User/UserService.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class UserService {
     
-    let userProvider = CustomMoyaProvider<UserAPI>(session: Session(interceptor: SessionInterceptor.shared))
+    let userProvider = CustomMoyaProvider<UserAPI>()
     
     init() { }
     
@@ -29,6 +29,7 @@ final class UserService {
                     print(error.localizedDescription, 500)
                 }
             case .failure(let err):
+                LoginService.shared.reissueApple(token: KeychainManager.shared.read("refreshToken") ?? "") { _ in }
                 print(err)
             }
         }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#143

👷 **작업한 내용**
- 서버에게 refreshToken 만료시간 축소요청
- SceneDelegate를 통해 앱이 background에서 넘어올때 예외처리를 진행함
- 통신 실패시 토큰 재발급 함수 실행되게끔 처리
- 액세스 토큰 또는 리프레쉬 토큰 만료 시에 Interceptor 수행되게끔 처리
- 리프레쉬 토큰 만료되면 로그인 뷰로 이동하는 알람 띄워주기

## 🚨참고 사항
혹시 만료로직 안먹히면 언제든 제보바람!

## 📸 스크린샷

<리프레쉬 토큰 만료 시의 모습>

https://github.com/team-winey/Winey-iOS/assets/40496065/12abb810-8ab6-441c-b6b4-f901be2b450f

## 📟 관련 이슈
- Resolved: #143 
