### PR TITLE
[Fix] #180 - 디스패치큐 메인에 endRefreshing() 추가

### DIFF
--- a/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
+++ b/Winey/Winey/Source/Scenes/Alert/ViewController/AlertViewController.swift
@@ -71,11 +71,9 @@ final class AlertViewController: UIViewController {
     }
     
     @objc private func refreshTableView() {
-        let delay: DispatchTime = .now() + 1.0
-        let closure: () -> Void = { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.getTotalAlert()
         }
-        DispatchQueue.main.asyncAfter(deadline: delay, execute: closure)
     }
 }
 
@@ -156,9 +154,12 @@ extension AlertViewController {
                 )
             }
             
-            self?.model = newArray
-            print("😀", data)
-        }
+            DispatchQueue.main.async { [weak self] in
+               
+                self?.refreshControl.endRefreshing()
+                self?.model = newArray
+                print("😀", data)
+            }        }
     }
     
     func pushState(at data: Category) {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#180

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
서버 측에서 DB를 교체한 후, 알림 삭제가 원활히 되어
새로고침 endRefreshing() 함수를 재작성하였습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

+DispatchQueue.main 에 함수를 작성하여 이렇게 함으로써 UI 업데이트가 메인 스레드에서 수행되기 때문에 앱이 더 부드럽게 동작하고 더 빠르게 응답하도록 개선하였습니다.

## 📸 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-09-14 at 08 26 35](https://github.com/team-winey/Winey-iOS/assets/105866831/b198b3de-f804-46d4-99b1-8a8df55c56f7)

## 📟 관련 이슈
- Resolved: #180 
