### PR TITLE
[Fix] #186 - 경고문구추가

### DIFF
--- a/Winey/Winey/Resource/Info.plist
+++ b/Winey/Winey/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/Winey/Winey/Source/Global/Extension/UIKit/UILabel+.swift
+++ b/Winey/Winey/Source/Global/Extension/UIKit/UILabel+.swift
@@ -38,4 +38,50 @@ extension UILabel {
             self.attributedText = attributedStr
         }
     }
+    
+    /// 특정 문자열에 밑줄을 추가하는 메서드
+    func setUnderLine(targetString: String) {
+        if let attributedText = self.attributedText?.mutableCopy() as? NSMutableAttributedString {
+            let fullText = attributedText.string
+            let range = (fullText as NSString).range(of: targetString)
+            
+            if range.location != NSNotFound {
+                attributedText.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+                self.attributedText = attributedText
+            }
+        }
+    }
+    
+    /// 라벨 내의 특정 문자열의 CGRect 을 반환
+    /// - Parameter subText: CGRect 을 알고 싶은 특정 문자열.
+    func rectFromString(with subText: String) -> CGRect? {
+        guard let attributedText = attributedText else { return nil }
+        guard let labelText = self.text else { return nil }
+        
+        // 전체 텍스트(labelText)에서 subText만큼의 range를 구합니다.
+        guard let subRange = labelText.range(of: subText) else { return nil }
+        let range = NSRange(subRange, in: labelText)
+        
+        // attributedText를 기반으로 한 NSTextStorage를 선언하고 NSLayoutManager를 추가합니다.
+        let layoutManager = NSLayoutManager()
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        textStorage.addLayoutManager(layoutManager)
+        
+        // instrinsicContentSize를 기반으로 NSTextContainer를 선언하고
+        let textContainer = NSTextContainer(size: intrinsicContentSize)
+        // 정확한 CGRect를 구해야하므로 padding 값은 0을 줍니다.
+        textContainer.lineFragmentPadding = 0.0
+        // layoutManager에 추가합니다.
+        layoutManager.addTextContainer(textContainer)
+        
+        var glyphRange = NSRange()
+        // 주어진 범위(rage)에 대한 실질적인 glyphRange를 구합니다.
+        layoutManager.characterRange(
+            forGlyphRange: range,
+            actualGlyphRange: &glyphRange
+        )
+        
+        // textContainer 내의 지정된 glyphRange에 대한 CGRect 값을 반환합니다.
+        return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+    }
 }

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -13,6 +13,7 @@ import UIKit
 import CHIPageControl
 import DesignSystem
 import SnapKit
+import SafariServices
 
 class UploadViewController: UIViewController {
     
@@ -165,7 +166,9 @@ class UploadViewController: UIViewController {
     }
 
     @objc private func tapWineyRule() {
-        print("탓치")
+        let url = URL(string: "https://empty-weaver-a9f.notion.site/iney-9dbfe130c7df4fb9a0903481c3e377e6?pvs=4")!
+        let safariViewController = SFSafariViewController(url: url)
+        self.present(safariViewController, animated: true)
     }
     
     private func makeTouchableRuleView() {

--- a/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
+++ b/Winey/Winey/Source/Scenes/Upload/ViewController/UploadViewController.swift
@@ -89,6 +89,8 @@ class UploadViewController: UIViewController {
         return view
     }()
     
+    private let warningLabel = UILabel()
+    
     /// nextButton: 다음 단계로 이동하는 하단 버튼
     private let nextButton: MIButton = {
         let btn = MIButton(type: .yellow)
@@ -108,6 +110,7 @@ class UploadViewController: UIViewController {
         setAddTarget()
         getData()
         setDelegate()
+        makeTouchableRuleView()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -146,12 +149,45 @@ class UploadViewController: UIViewController {
                 
         nextButton.setTitle(stageIdx == 2 ? "업로드" : "다음", for: .normal)
         
+        warningLabel.text = Const.warningString
+        warningLabel.numberOfLines = 0
+        warningLabel.isUserInteractionEnabled = true
+        warningLabel.setText(Const.warningString, attributes: Const.warningAttributes)
+        warningLabel.setUnderLine(targetString: "위니 이용약관의 13조")
+        
         /// 업로드 뷰 단계에 따라서 네비게이션바 좌측 버튼에 다른 이미지가 들어가도록 함
         switch stageIdx {
         case 1, 2:
             navigationBar.leftBarItem = .back
         default:
             navigationBar.leftBarItem = .close
+        }
+    }
+
+    @objc private func tapWineyRule() {
+        print("탓치")
+    }
+    
+    private func makeTouchableRuleView() {
+        if let rect = warningLabel.rectFromString(with: "위니 이용약관의 13조") {
+            // CGRect를 기반으로 10씩 확장
+            let expandedRect = CGRect(
+                x: rect.origin.x - 10,
+                y: rect.origin.y + 15,
+                width: rect.size.width + 20,
+                height: rect.size.height + 20
+            )
+
+            let touchableView = UIView(frame: expandedRect)
+            
+            touchableView.backgroundColor = .clear
+            
+            touchableView.isUserInteractionEnabled = true
+            
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapWineyRule))
+            touchableView.addGestureRecognizer(tapGesture)
+            
+            self.warningLabel.addSubview(touchableView)
         }
     }
     
@@ -178,7 +214,7 @@ class UploadViewController: UIViewController {
     private func setLayout() {
         setScrollView()
         
-        view.addSubviews(navigationBar, grayDot, pageGuide, scrollView, nextButton)
+        view.addSubviews(navigationBar, grayDot, pageGuide, scrollView, warningLabel, nextButton)
         
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(safeArea)
@@ -205,6 +241,11 @@ class UploadViewController: UIViewController {
             $0.bottom.equalTo(safeArea).inset(4)
             $0.height.equalTo(52)
             $0.horizontalEdges.equalToSuperview().inset(10)
+        }
+        
+        warningLabel.snp.makeConstraints {
+            $0.bottom.equalTo(nextButton.snp.top).offset(-15)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(15)
         }
     }
     
@@ -437,6 +478,8 @@ class UploadViewController: UIViewController {
             make.bottom.equalTo(view.safeAreaLayoutGuide)
                 .inset(adjustedBottomSpace)
         }
+        warningLabel.isHidden = true
+        
         view.layoutIfNeeded()
     }
     
@@ -445,6 +488,7 @@ class UploadViewController: UIViewController {
         self.nextButton.snp.updateConstraints { make in
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(12)
         }
+        warningLabel.isHidden = false
         view.layoutIfNeeded()
     }
 }
@@ -482,5 +526,17 @@ extension UploadViewController {
             loadingViewController.feedUploadResult = result
         }
         self.navigationController?.pushViewController(loadingViewController, animated: true)
+    }
+}
+
+extension UploadViewController {
+    enum Const {
+        static let warningString = "위니는 긍정적인 소비습관을 함께 만들어 나가는 커뮤니티입니다. 긍정적인 커뮤니티를 만들기 위해 커뮤니티 이용 규칙을 제정하여 운영하고 있습니다. 위반 시 게시물이 삭제 되고 계정이 일정 기간 제한될 수 있습니다. \n더 자세한 이용 규칙은 위니 이용약관의 13조를 참고해주세요."
+        
+        static let warningAttributes = Typography.Attributes(
+            style: .detail3,
+            weight: .medium,
+            textColor: .winey_gray400
+        )
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#186

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
 작성 뷰 하단에 라벨 및 노션 링크 추가

1. 키보드를 내릴 때마다 보이는 플로우로 수정했습니다
   (키보드가 올라올 때 다음 버튼이랑 같이 올라오면서 SE나 미니경우엔 절약내용 작성하는 텍스트뷰랑 겹쳐지는 이슈가 있어서)
   작성 뷰가 키보드가 올라갈 때 스크롤이 되지 않아서 SE는 지금 키보드가 올라갈 때에도 뷰가 조금 겹치는 상황이에요. 
   추후에 확인 부탁드립니다. 하하.. @alpha-kwhn 

2. 글자에서 위아래 양옆으로 10정도 더 터치영역을 넓혀놨어요( 하단에 터치영역 참고) 

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="353" alt="image" src="https://github.com/team-winey/Winey-iOS/assets/83493636/df4ec722-3653-4aac-b3d8-f99f67cd3008">

아이폰 업데이트를 하면서 엑스코드 업데이트를 했는데
그 이후에 http 접근 허용에 관련해서 에러가 뜨면서 시뮬이 돌아가지 않아서 설정을 바꿔두고 작업했는데
다들 잘 되시는지 확인 부탁드릴게용

## 📸 스크린샷
슬랙에 올린 시뮬영상입니다.
https://wwiney.slack.com/archives/C05CZHG03T7/p1695835047368729

+ 터치 영역
<img src = "https://github.com/team-winey/Winey-iOS/assets/83493636/466fcee9-e081-4702-a767-44d5dd34a5af" width ="250">

## 📟 관련 이슈
- Resolved: #186 
